### PR TITLE
Implement a CD release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           artifact-name: ${{ matrix.artifact }}
+          artifact-prefix: asimov
           binary-name: asimov
           binary-extension: ${{ matrix.extension }}
           strip-artifact: ${{ matrix.strip || 'false' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           artifact-name: ${{ matrix.artifact }}
+          binary-name: asimov
           binary-extension: ${{ matrix.extension }}
           strip-artifact: ${{ matrix.strip || 'false' }}
           use-zigbuild: ${{ matrix.use-zigbuild || 'false' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+# See: https://docs.github.com/en/actions/writing-workflows
+---
+name: Release
+
+# Trigger on any tag creation:
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: linux-x86
+            target: x86_64-unknown-linux-gnu
+            strip: true
+          - os: ubuntu-latest
+            artifact: linux-arm
+            target: aarch64-unknown-linux-gnu
+            use-zigbuild: true
+          - os: ubuntu-latest
+            artifact: macos-x86
+            target: x86_64-apple-darwin
+            use-zigbuild: true
+          - os: ubuntu-latest
+            artifact: macos-arm
+            target: aarch64-apple-darwin
+            use-zigbuild: true
+          - os: ubuntu-latest
+            artifact: windows-x64
+            target: x86_64-pc-windows-gnu
+            extension: exe
+    name: Build ${{ matrix.artifact }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: false
+    steps:
+      - name: Build
+        uses: asimov-platform/build-rust-action@v1
+        with:
+          target: ${{ matrix.target }}
+          artifact-name: ${{ matrix.artifact }}
+          binary-extension: ${{ matrix.extension }}
+          strip-artifact: ${{ matrix.strip || 'false' }}
+          use-zigbuild: ${{ matrix.use-zigbuild || 'false' }}
+          rust-toolchain: 1.81.0
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: asimov-platform/release-action@v1
+        with:
+          changelog-path: CHANGES.md


### PR DESCRIPTION
Closes #2.

This pull request adds a fairly simple CD action that is triggered on a tag push. It then builds the CLI for next platforms:
- Linux x86
- Linux ARM
- macOS x86
- macOS ARM
- Windows x86

Then, it parses changes from `CHANGES.MD` file and creates a release, looking like this:
![image](https://github.com/user-attachments/assets/cd1efa58-423e-4269-8f0a-3d4e20e6ff08)

NOTE: Since there were no changes in `CHANGES.MD`, the body of release is empty, thus github added a placeholder.

@race-of-sloths include!