### PR TITLE
Add a `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,3 @@ root = true
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
-insert_final_newline = true


### PR DESCRIPTION
Since we want to enforce unix-like end of lines, while I believe catching it in a post-commit hook, as you suggested, is a good idea, it would also be good idea to make IDE aware of our preferences beforehand.
[.editorconfig](https://editorconfig.org) not only works out of the box for [VIM, NVIM, but also git & github](https://editorconfig.org/#pre-installed)!

The simple config provided in this PR sets unix-like ends of lines, UTF-8 charset and to trim trailing whitespaces.

@race-of-sloths include!