### PR TITLE
Pass PAT to the release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download artifacts
-        uses: asimov-platform/release-action@v1
+      - name: Release
+        uses: asimov-platform/release-action@v2
         with:
+          token: ${{ secrets.PAT_RELEASE }}
           changelog-path: CHANGES.md


### PR DESCRIPTION
Doing so is a workaround for an [issue](https://github.com/orgs/community/discussions/25281) where GitHub doesn't trigger events that are caused by GitHub Actions. Using Personal Access Token would fix it, letting us catch "release" event and running other actions accordingly.

This PR is a cornerstone for other PRs that depend on fixed behavior.

It also fixes step name which is for some reason is wrong.

@race-of-sloths include!