### PR TITLE
Fix Glibc version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: linux-x86
-            target: x86_64-unknown-linux-gnu
-            strip: true
+            target: x86_64-unknown-linux-gnu.2.28
+            use-zigbuild: true
           - os: ubuntu-latest
             artifact: linux-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-gnu.2.28
             use-zigbuild: true
           - os: ubuntu-latest
             artifact: macos-x86

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,13 +15,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact: linux-x86
+            artifact: linux-x86-gnu
             target: x86_64-unknown-linux-gnu.2.28
             use-zigbuild: true
           - os: ubuntu-latest
-            artifact: linux-arm
+            artifact: linux-arm-gnu
             target: aarch64-unknown-linux-gnu.2.28
             use-zigbuild: true
+          - os: ubuntu-latest
+            artifact: linux-x86-musl
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            artifact: linux-arm-musl
+            target: aarch64-unknown-linux-musl
           - os: ubuntu-latest
             artifact: macos-x86
             target: x86_64-apple-darwin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,14 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: linux-x86-gnu
-            target: x86_64-unknown-linux-gnu.2.28
+            target: x86_64-unknown-linux-gnu
             use-zigbuild: true
+            glibc-version: 2.28
           - os: ubuntu-latest
             artifact: linux-arm-gnu
-            target: aarch64-unknown-linux-gnu.2.28
+            target: aarch64-unknown-linux-gnu
             use-zigbuild: true
+            glibc-version: 2.28
           - os: ubuntu-latest
             artifact: linux-x86-musl
             target: x86_64-unknown-linux-musl
@@ -45,7 +47,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Build
-        uses: asimov-platform/build-rust-action@v1
+        uses: asimov-platform/build-rust-action@v2
         with:
           target: ${{ matrix.target }}
           artifact-name: ${{ matrix.artifact }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
           - os: ubuntu-latest
             artifact: linux-arm-musl
             target: aarch64-unknown-linux-musl
+            use-zigbuild: true
           - os: ubuntu-latest
             artifact: macos-x86
             target: x86_64-apple-darwin


### PR DESCRIPTION
Currently because we build application on Ubuntu 24.02, it is getting linked to Glibc version 2.39, which is a newer one, causing problems running on [older Linux systems](https://github.com/asimov-platform/homebrew-tap/actions/runs/13685343551/job/38267364793?pr=4#step:7:52). This PR fixes that by linking to Glibc version 2.28, included by default starting from Ubuntu 19.04, Debian 10 and other distributions from 2019.

However, in case people don't have Glibc of the right version this PR introduces binaries with no Glibc dependencies at all, which use musl instead.

![image](https://github.com/user-attachments/assets/1bd7e1df-8df5-4f3b-9a03-4f3292bd2b5d)

@race-of-sloths include!