### PR TITLE
Implement `help CMD` subcommands & slight refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cc = "1.1"
 
 [dev-dependencies]
 temp-dir = "0.1.14"
+indoc = "2.0.6"
 
 [dependencies]
 clap = { version = "4.5", default-features = false }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,8 @@
+// This is free and unencumbered software released into the public domain.
+
+mod external;
+mod help;
+mod help_cmd;
+pub use external::*;
+pub use help::*;
+pub use help_cmd::*;

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -7,11 +7,11 @@ use crate::shared::locate_subcommand;
 use crate::Result;
 
 /// Executes the given subcommand.
-pub struct ExternalCmd {
+pub struct External {
     pub is_debug: bool,
 }
 
-impl ExternalCmd {
+impl External {
     pub fn execute(&self, cmd: &str, args: &[String]) -> Result<i32> {
         // Locate the given subcommand:
         let cmd = locate_subcommand(cmd)?;

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,0 +1,54 @@
+// This is free and unencumbered software released into the public domain.
+
+use clientele::SysexitsError::*;
+use std::process::Stdio;
+
+use crate::shared::locate_subcommand;
+use crate::Result;
+
+/// Executes the given subcommand.
+pub struct ExternalCmd {
+    pub is_debug: bool,
+}
+
+impl ExternalCmd {
+    pub fn execute(&self, cmd: &str, args: &[String]) -> Result<i32> {
+        // Locate the given subcommand:
+        let cmd = locate_subcommand(cmd)?;
+
+        // Execute the given subcommand:
+        let status = std::process::Command::new(&cmd.path)
+            .args(args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status();
+
+        match status {
+            Err(error) => {
+                if self.is_debug {
+                    eprintln!("{}: {}", "asimov", error);
+                }
+                Err(EX_SOFTWARE)
+            }
+            Ok(status) => {
+                use std::process::exit;
+
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+
+                    if let Some(signal) = status.signal() {
+                        if self.is_debug {
+                            eprintln!("{}: terminated by signal {}", "asimov", signal);
+                        }
+                        exit((signal | 0x80) & 0xff)
+                    }
+                }
+
+                // unwrap_or should never happen because we are handling signal above.
+                exit(status.code().unwrap_or(EX_SOFTWARE.as_i32()))
+            }
+        }
+    }
+}

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -32,8 +32,6 @@ impl ExternalCmd {
                 Err(EX_SOFTWARE)
             }
             Ok(status) => {
-                use std::process::exit;
-
                 #[cfg(unix)]
                 {
                     use std::os::unix::process::ExitStatusExt;
@@ -42,12 +40,12 @@ impl ExternalCmd {
                         if self.is_debug {
                             eprintln!("{}: terminated by signal {}", "asimov", signal);
                         }
-                        exit((signal | 0x80) & 0xff)
+                        return Ok((signal | 0x80) & 0xff);
                     }
                 }
 
                 // unwrap_or should never happen because we are handling signal above.
-                exit(status.code().unwrap_or(EX_SOFTWARE.as_i32()))
+                Ok(status.code().unwrap_or(EX_SOFTWARE.as_i32()))
             }
         }
     }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -1,51 +1,79 @@
 // This is free and unencumbered software released into the public domain.
 
 use clientele::SysexitsError::*;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 
 use crate::shared::locate_subcommand;
 use crate::Result;
 
+pub struct ExternalResult {
+    pub code: i32,
+    pub stdout: Option<Vec<u8>>,
+    pub stderr: Option<Vec<u8>>,
+}
+
 /// Executes the given subcommand.
 pub struct External {
     pub is_debug: bool,
+    pub pipe_output: bool,
 }
 
 impl External {
-    pub fn execute(&self, cmd: &str, args: &[String]) -> Result<i32> {
+    pub fn execute(&self, cmd: &str, args: &[String]) -> Result<ExternalResult> {
         // Locate the given subcommand:
         let cmd = locate_subcommand(cmd)?;
 
-        // Execute the given subcommand:
-        let status = std::process::Command::new(&cmd.path)
-            .args(args)
-            .stdin(Stdio::inherit())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .status();
+        // Prepare the process:
+        let result: std::io::Result<(ExitStatus, Option<Vec<u8>>, Option<Vec<u8>>)> =
+            if self.pipe_output {
+                std::process::Command::new(&cmd.path)
+                    .args(args)
+                    .stdin(Stdio::inherit())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .output()
+                    .map(|x| (x.status, Some(x.stdout), Some(x.stderr)))
+            } else {
+                std::process::Command::new(&cmd.path)
+                    .args(args)
+                    .stdin(Stdio::inherit())
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .status()
+                    .map(|x| (x, None, None))
+            };
 
-        match status {
+        match result {
             Err(error) => {
                 if self.is_debug {
                     eprintln!("{}: {}", "asimov", error);
                 }
                 Err(EX_SOFTWARE)
             }
-            Ok(status) => {
+            Ok(result) => {
                 #[cfg(unix)]
                 {
                     use std::os::unix::process::ExitStatusExt;
 
-                    if let Some(signal) = status.signal() {
+                    if let Some(signal) = result.0.signal() {
                         if self.is_debug {
                             eprintln!("{}: terminated by signal {}", "asimov", signal);
                         }
-                        return Ok((signal | 0x80) & 0xff);
+
+                        return Ok(ExternalResult {
+                            code: (signal | 0x80) & 0xff,
+                            stdout: result.1,
+                            stderr: result.2,
+                        });
                     }
                 }
 
-                // unwrap_or should never happen because we are handling signal above.
-                Ok(status.code().unwrap_or(EX_SOFTWARE.as_i32()))
+                Ok(ExternalResult {
+                    // unwrap_or should never happen because we are handling signal above.
+                    code: result.0.code().unwrap_or(EX_SOFTWARE.as_i32()),
+                    stdout: result.1,
+                    stderr: result.2,
+                })
             }
         }
     }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -7,8 +7,13 @@ use crate::shared::locate_subcommand;
 use crate::Result;
 
 pub struct ExternalResult {
+    /// Return code of the executed command.
     pub code: i32,
+
+    /// If `pipe_output` is `true`, this field contains stdout, otherwise its None.
     pub stdout: Option<Vec<u8>>,
+
+    /// If `pipe_output` is `true`, this field contains stderr, otherwise its None.
     pub stderr: Option<Vec<u8>>,
 }
 

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,0 +1,12 @@
+// This is free and unencumbered software released into the public domain.
+
+use crate::Result;
+
+/// Prints extensive help message, executing `help` command for each subcommand.
+pub struct HelpCommand;
+
+impl HelpCommand {
+    pub fn execute(&self) -> Result {
+        unimplemented!()
+    }
+}

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -3,9 +3,9 @@
 use crate::Result;
 
 /// Prints extensive help message, executing `help` command for each subcommand.
-pub struct HelpCommand;
+pub struct Help;
 
-impl HelpCommand {
+impl Help {
     pub fn execute(&self) -> Result {
         unimplemented!()
     }

--- a/src/commands/help_cmd.rs
+++ b/src/commands/help_cmd.rs
@@ -1,0 +1,60 @@
+// This is free and unencumbered software released into the public domain.
+
+use clientele::SysexitsError::*;
+use std::process::Stdio;
+
+use crate::shared::locate_subcommand;
+use crate::Result;
+
+/// Executes `help` command for the given subcommand.
+pub struct HelpCmdCommand {
+    pub is_debug: bool,
+}
+
+impl HelpCmdCommand {
+    pub fn execute(&self, cmd: &str, args: &[String]) -> Result {
+        // Locate the given subcommand:
+        let cmd = locate_subcommand(cmd)?;
+
+        // Execute the `--help` command:
+        let output = std::process::Command::new(&cmd.path)
+            .args([&[String::from("--help")], args].concat())
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
+
+        match output {
+            Err(error) => {
+                if self.is_debug {
+                    eprintln!("{}: {}", "asimov", error);
+                }
+                Err(EX_SOFTWARE)
+            }
+            Ok(output) => match output.status.code() {
+                Some(code) if code == EX_OK.as_i32() => {
+                    use std::process::exit;
+
+                    let stdout = std::io::stdout();
+                    let mut stdout = stdout.lock();
+                    std::io::copy(&mut output.stdout.as_slice(), &mut stdout).unwrap();
+
+                    exit(output.status.code().unwrap_or(EX_SOFTWARE.as_i32()))
+                }
+                _ => {
+                    eprintln!("{}: {} doesn't provide help", "asimov", cmd.name);
+
+                    if self.is_debug {
+                        eprintln!("{}: status code - {}", "asimov", output.status);
+
+                        let stdout = std::io::stdout();
+                        let mut stdout = stdout.lock();
+                        std::io::copy(&mut output.stderr.as_slice(), &mut stdout).unwrap();
+                    }
+
+                    Err(EX_SOFTWARE)
+                }
+            },
+        }
+    }
+}

--- a/src/commands/help_cmd.rs
+++ b/src/commands/help_cmd.rs
@@ -7,11 +7,11 @@ use crate::shared::locate_subcommand;
 use crate::Result;
 
 /// Executes `help` command for the given subcommand.
-pub struct HelpCmdCommand {
+pub struct HelpCmd {
     pub is_debug: bool,
 }
 
-impl HelpCmdCommand {
+impl HelpCmd {
     pub fn execute(&self, cmd: &str, args: &[String]) -> Result<i32> {
         // Locate the given subcommand:
         let cmd = locate_subcommand(cmd)?;

--- a/src/commands/help_cmd.rs
+++ b/src/commands/help_cmd.rs
@@ -12,7 +12,7 @@ pub struct HelpCmdCommand {
 }
 
 impl HelpCmdCommand {
-    pub fn execute(&self, cmd: &str, args: &[String]) -> Result {
+    pub fn execute(&self, cmd: &str, args: &[String]) -> Result<i32> {
         // Locate the given subcommand:
         let cmd = locate_subcommand(cmd)?;
 
@@ -33,13 +33,11 @@ impl HelpCmdCommand {
             }
             Ok(output) => match output.status.code() {
                 Some(code) if code == EX_OK.as_i32() => {
-                    use std::process::exit;
-
                     let stdout = std::io::stdout();
                     let mut stdout = stdout.lock();
                     std::io::copy(&mut output.stdout.as_slice(), &mut stdout).unwrap();
 
-                    exit(output.status.code().unwrap_or(EX_SOFTWARE.as_i32()))
+                    Ok(output.status.code().unwrap_or(EX_SOFTWARE.as_i32()))
                 }
                 _ => {
                     eprintln!("{}: {} doesn't provide help", "asimov", cmd.name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 // This is free and unencumbered software released into the public domain.
 
-mod external_commands;
-pub use external_commands::*;
+mod subcommands_provider;
+pub use subcommands_provider::*;
+
+use clientele::SysexitsError;
+
+pub type Result<T = SysexitsError, E = SysexitsError> = std::result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 // This is free and unencumbered software released into the public domain.
 
+pub mod commands;
+pub mod shared;
+
 mod subcommands_provider;
 pub use subcommands_provider::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,13 @@
 mod feature;
 
 use clientele::{
-    crates::clap::{CommandFactory, Parser, Subcommand},
+    crates::clap::{CommandFactory, Parser, Subcommand as ClapSubcommand},
     StandardOptions,
     SysexitsError::{self, *},
 };
 use std::process::Stdio;
 
-use asimov_cli::{ExternalCommand, ExternalCommands};
+use asimov_cli::{Result, Subcommand, SubcommandsProvider};
 
 /// ASIMOV Command-Line Interface (CLI)
 #[derive(Debug, Parser)]
@@ -31,7 +31,7 @@ struct Options {
     command: Option<Command>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, ClapSubcommand)]
 enum Command {
     // FIXME: `help` command is not listed in the help message.
     Help {
@@ -41,8 +41,6 @@ enum Command {
     #[clap(external_subcommand)]
     External(Vec<String>),
 }
-
-type Result<T = SysexitsError, E = SysexitsError> = std::result::Result<T, E>;
 
 pub fn main() -> SysexitsError {
     // Load environment variables from `.env`:
@@ -102,7 +100,7 @@ fn print_help() {
     let mut help = String::new();
     help.push_str(color_print::cstr!("<s><u>Commands:</u></s>\n"));
 
-    let commands = ExternalCommands::collect("asimov-", 1);
+    let commands = SubcommandsProvider::collect("asimov-", 1);
     for (i, cmd) in commands.iter().enumerate() {
         if i > 0 {
             help.push('\n');
@@ -126,8 +124,8 @@ fn execute_extensive_help() -> Result {
 }
 
 /// Locates the given subcommand or prints an error.
-fn locate_subcommand(name: &str) -> Result<ExternalCommand> {
-    match ExternalCommands::find("asimov-", name) {
+fn locate_subcommand(name: &str) -> Result<Subcommand> {
+    match SubcommandsProvider::find("asimov-", name) {
         Some(cmd) => Ok(cmd),
         None => {
             eprintln!("{}: command not found: {}{}", "asimov", "asimov-", name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use clientele::{
 };
 
 use asimov_cli::{
-    commands::{ExternalCmd, HelpCmdCommand, HelpCommand},
+    commands::{External, Help, HelpCmd},
     SubcommandsProvider,
 };
 
@@ -82,7 +82,7 @@ pub fn main() -> SysexitsError {
     let result = match options.command.as_ref().unwrap() {
         Command::Help { args } => {
             if let Some(cmd_name) = args.first() {
-                let cmd = HelpCmdCommand {
+                let cmd = HelpCmd {
                     is_debug: options.flags.debug,
                 };
 
@@ -90,12 +90,12 @@ pub fn main() -> SysexitsError {
                 let result = cmd.execute(cmd_name, &args[1..]);
                 Ok(EX_OK)
             } else {
-                let cmd = HelpCommand;
+                let cmd = Help;
                 cmd.execute()
             }
         }
         Command::External(args) => {
-            let cmd = ExternalCmd {
+            let cmd = External {
                 is_debug: options.flags.debug,
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ pub fn main() -> SysexitsError {
                 };
 
                 let result = cmd.execute(cmd_name, &args[1..]);
-                if let Ok(result) = result {
+                if let Ok(result) = &result {
                     if result.success {
                         let stdout = std::io::stdout();
                         let mut stdout = stdout.lock();
@@ -105,8 +105,7 @@ pub fn main() -> SysexitsError {
                     }
                 }
 
-                // FIXME: Handle i32 result.
-                Ok(EX_OK)
+                result.map(|result| result.code)
             } else {
                 let cmd = Help;
                 cmd.execute()
@@ -118,17 +117,15 @@ pub fn main() -> SysexitsError {
                 pipe_output: false,
             };
 
-            // FIXME: Handle i32 result.
-            let result = cmd.execute(&args[0], &args[1..]);
-            Ok(EX_OK)
+            cmd.execute(&args[0], &args[1..]).map(|result| result.code)
         }
     };
 
-    // We can handle result here if we want.
-    match result {
-        Ok(code) => code,
-        Err(code) => code,
-    }
+    // Return whatever status code we got.
+    // NOTE: We could return Result<...> here, however
+    // in that case we would get an annoying `Error: ...` message,
+    // which is not what we want. So we just return an error like this.
+    result.unwrap_or_else(|e| e)
 }
 
 /// Prints basic help message.

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ pub fn main() -> SysexitsError {
         Command::External(args) => {
             let cmd = External {
                 is_debug: options.flags.debug,
+                pipe_output: false,
             };
 
             // FIXME: Handle i32 result.

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,26 @@ pub fn main() -> SysexitsError {
                     is_debug: options.flags.debug,
                 };
 
-                // FIXME: Handle i32 result.
                 let result = cmd.execute(cmd_name, &args[1..]);
+                if let Ok(result) = result {
+                    if result.success {
+                        let stdout = std::io::stdout();
+                        let mut stdout = stdout.lock();
+                        std::io::copy(&mut result.output.as_slice(), &mut stdout).unwrap();
+                    } else {
+                        eprintln!("{}: {} doesn't provide help", "asimov", cmd_name);
+
+                        if options.flags.debug {
+                            eprintln!("{}: status code - {}", "asimov", result.code);
+
+                            let stdout = std::io::stdout();
+                            let mut stdout = stdout.lock();
+                            std::io::copy(&mut result.output.as_slice(), &mut stdout).unwrap();
+                        }
+                    }
+                }
+
+                // FIXME: Handle i32 result.
                 Ok(EX_OK)
             } else {
                 let cmd = Help;

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,9 +143,9 @@ fn execute_help_command(options: &Options, command: &[String]) -> Result {
     // Locate the given subcommand:
     let cmd = locate_subcommand(&command[0])?;
 
-    // Execute the `help` command:
+    // Execute the `--help` command:
     let output = std::process::Command::new(&cmd.path)
-        .args(&[&[String::from("help")], &command[1..]].concat())
+        .args([&[String::from("--help")], &command[1..]].concat())
         .stdin(Stdio::inherit())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,12 @@ mod feature;
 
 use clientele::{
     crates::clap::{CommandFactory, Parser, Subcommand},
-    exit, StandardOptions,
-    SysexitsError::*,
+    StandardOptions,
+    SysexitsError::{self, *},
 };
 use std::process::Stdio;
 
-use asimov_cli::ExternalCommands;
+use asimov_cli::{ExternalCommand, ExternalCommands};
 
 /// ASIMOV Command-Line Interface (CLI)
 #[derive(Debug, Parser)]
@@ -33,17 +33,24 @@ struct Options {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    // FIXME: `help` command is not listed in the help message.
+    Help {
+        #[clap(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
     #[clap(external_subcommand)]
     External(Vec<String>),
 }
 
-pub fn main() {
+type Result<T = SysexitsError, E = SysexitsError> = std::result::Result<T, E>;
+
+pub fn main() -> Result {
     // Load environment variables from `.env`:
     clientele::dotenv().ok();
 
     // Expand wildcards and @argfiles:
     let Ok(args) = clientele::args_os() else {
-        exit(EX_USAGE);
+        return Err(EX_USAGE);
     };
 
     // Parse command-line options:
@@ -52,13 +59,13 @@ pub fn main() {
     // Print the version, if requested:
     if options.flags.version {
         println!("ASIMOV {}", env!("CARGO_PKG_VERSION"));
-        exit(EX_OK);
+        return Ok(EX_OK);
     }
 
     // Print the license, if requested:
     if options.flags.license {
         print!("{}", include_str!("../UNLICENSE"));
-        exit(EX_OK);
+        return Ok(EX_OK);
     }
 
     // Configure debug output:
@@ -68,41 +75,65 @@ pub fn main() {
 
     // Print the help message, if requested:
     if options.help {
-        let mut help = String::new();
-        help.push_str(color_print::cstr!("<s><u>Commands:</u></s>\n"));
-
-        let commands = ExternalCommands::collect("asimov-", 1);
-        for (i, cmd) in commands.iter().enumerate() {
-            if i > 0 {
-                help.push('\n');
-            }
-            help.push_str(&color_print::cformat!(
-                "\t<dim>$</dim> <s>asimov {}</s> [OPTIONS] [COMMAND]",
-                cmd.name,
-            ));
-        }
-
-        Options::command()
-            .after_long_help(help)
-            .print_long_help()
-            .unwrap();
-
-        exit(EX_OK);
+        return execute_help();
     }
 
-    // Locate the given subcommand:
-    let Command::External(command) = &options.command.unwrap();
-    let Some(cmd_to_execute) = ExternalCommands::find("asimov-", &command[0]) else {
-        eprintln!(
-            "{}: command not found: {}{}",
-            "asimov", "asimov-", command[0]
-        );
-        exit(EX_UNAVAILABLE);
-    };
+    match options.command.as_ref().unwrap() {
+        Command::Help { args } => {
+            if args.is_empty() {
+                execute_extensive_help()
+            } else {
+                execute_help_command(&options, args)
+            }
+        }
+        Command::External(command) => execute_external_command(&options, command),
+    }
+}
 
-    // Execute the given subcommand:
-    let status = std::process::Command::new(&cmd_to_execute.path)
-        .args(&command[1..])
+/// Prints basic help message.
+fn execute_help() -> Result {
+    let mut help = String::new();
+    help.push_str(color_print::cstr!("<s><u>Commands:</u></s>\n"));
+
+    let commands = ExternalCommands::collect("asimov-", 1);
+    for (i, cmd) in commands.iter().enumerate() {
+        if i > 0 {
+            help.push('\n');
+        }
+        println!("{}", cmd.path.display());
+        help.push_str(&color_print::cformat!(
+            "\t<dim>$</dim> <s>asimov {}</s> [OPTIONS] [COMMAND]",
+            cmd.name,
+        ));
+    }
+
+    Options::command()
+        .after_long_help(help)
+        .print_long_help()
+        .unwrap();
+
+    Ok(EX_OK)
+}
+
+/// Prints extensive help message, executing `help` command for each subcommand.
+fn execute_extensive_help() -> Result {
+    unimplemented!()
+}
+
+/// Locates the given subcommand or prints an error.
+fn locate_subcommand(name: &str) -> Result<ExternalCommand> {
+    match ExternalCommands::find("asimov-", name) {
+        Some(cmd) => Ok(cmd),
+        None => {
+            eprintln!("{}: command not found: {}{}", "asimov", "asimov-", name);
+            Err(EX_UNAVAILABLE)
+        }
+    }
+}
+
+fn execute_subcommand(options: &Options, cmd: &ExternalCommand, args: &[String]) -> Result {
+    let status = std::process::Command::new(&cmd.path)
+        .args(args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -113,7 +144,7 @@ pub fn main() {
             if options.flags.debug {
                 eprintln!("{}: {}", "asimov", error);
             }
-            exit(EX_SOFTWARE);
+            Err(EX_SOFTWARE)
         }
         Ok(status) => {
             use std::process::exit;
@@ -126,11 +157,38 @@ pub fn main() {
                     if options.flags.debug {
                         eprintln!("{}: terminated by signal {}", "asimov", signal);
                     }
-                    exit((signal | 0x80) & 0xff);
+                    exit((signal | 0x80) & 0xff)
                 }
             }
 
+            // unwrap_or should never happen because we are handling signal above.
             exit(status.code().unwrap_or(EX_SOFTWARE.as_i32()))
         }
     }
+}
+
+/// Executes `help` command for the given subcommand.
+fn execute_help_command(options: &Options, command: &[String]) -> Result {
+    assert!(!command.is_empty());
+
+    // Locate the given subcommand:
+    let cmd = locate_subcommand(&command[0])?;
+
+    // Execute the `help` command:
+    execute_subcommand(
+        options,
+        &cmd,
+        &[&[String::from("help")], &command[1..]].concat(),
+    )
+}
+
+/// Executes the given subcommand.
+fn execute_external_command(options: &Options, command: &[String]) -> Result {
+    assert!(!command.is_empty());
+
+    // Locate the given subcommand:
+    let cmd = locate_subcommand(&command[0])?;
+
+    // Execute the given subcommand:
+    execute_subcommand(options, &cmd, &command[1..])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,10 @@ pub fn main() -> SysexitsError {
                 let cmd = HelpCmdCommand {
                     is_debug: options.flags.debug,
                 };
-                cmd.execute(cmd_name, &args[1..])
+
+                // FIXME: Handle i32 result.
+                let result = cmd.execute(cmd_name, &args[1..]);
+                Ok(EX_OK)
             } else {
                 let cmd = HelpCommand;
                 cmd.execute()
@@ -96,9 +99,8 @@ pub fn main() -> SysexitsError {
                 is_debug: options.flags.debug,
             };
 
-            let result = cmd.execute(&args[0], &args[1..]);
             // FIXME: Handle i32 result.
-
+            let result = cmd.execute(&args[0], &args[1..]);
             Ok(EX_OK)
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn print_help() {
         if i > 0 {
             help.push('\n');
         }
-        println!("{}", cmd.path.display());
+
         help.push_str(&color_print::cformat!(
             "\t<dim>$</dim> <s>asimov {}</s> [OPTIONS] [COMMAND]",
             cmd.name,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,15 @@
+// This is free and unencumbered software released into the public domain.
+
+use crate::{Result, Subcommand, SubcommandsProvider};
+use clientele::SysexitsError::*;
+
+/// Locates the given subcommand or prints an error.
+pub fn locate_subcommand(name: &str) -> Result<Subcommand> {
+    match SubcommandsProvider::find("asimov-", name) {
+        Some(cmd) => Ok(cmd),
+        None => {
+            eprintln!("{}: command not found: {}{}", "asimov", "asimov-", name);
+            Err(EX_UNAVAILABLE)
+        }
+    }
+}

--- a/src/subcommands_provider.rs
+++ b/src/subcommands_provider.rs
@@ -3,18 +3,18 @@
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ExternalCommand {
+pub struct Subcommand {
     pub name: String,
     pub path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
-pub struct ExternalCommands {
-    commands: Vec<ExternalCommand>,
+pub struct SubcommandsProvider {
+    commands: Vec<Subcommand>,
 }
 
-impl ExternalCommands {
-    pub fn collect(prefix: &str, level: usize) -> ExternalCommands {
+impl SubcommandsProvider {
+    pub fn collect(prefix: &str, level: usize) -> SubcommandsProvider {
         let commands = Self::collect_commands(prefix)
             .into_iter()
             // Construct ExternalCommand.
@@ -25,7 +25,7 @@ impl ExternalCommands {
                     .trim_start_matches(prefix)
                     .to_string();
 
-                Some(ExternalCommand { name, path })
+                Some(Subcommand { name, path })
             })
             // Respect level.
             .filter(|cmd| {
@@ -34,24 +34,24 @@ impl ExternalCommands {
             })
             .collect();
 
-        ExternalCommands { commands }
+        SubcommandsProvider { commands }
     }
 
-    pub fn find(prefix: &str, name: &str) -> Option<ExternalCommand> {
+    pub fn find(prefix: &str, name: &str) -> Option<Subcommand> {
         let name = format!("{}{}", prefix, name);
         let path = Self::resolve_command(prefix, &name);
-        path.map(|path| ExternalCommand { name, path })
+        path.map(|path| Subcommand { name, path })
     }
 }
 
-impl ExternalCommands {
-    pub fn iter(&self) -> impl Iterator<Item = &ExternalCommand> {
+impl SubcommandsProvider {
+    pub fn iter(&self) -> impl Iterator<Item = &Subcommand> {
         self.commands.iter()
     }
 }
 
 #[cfg(unix)]
-impl ExternalCommands {
+impl SubcommandsProvider {
     fn filter_file(prefix: &str, path: &Path) -> bool {
         use std::os::unix::prelude::*;
 
@@ -137,7 +137,7 @@ impl ExternalCommands {
 }
 
 #[cfg(windows)]
-impl ExternalCommands {
+impl SubcommandsProvider {
     fn get_path_exts() -> Option<Vec<String>> {
         let Ok(exts) = std::env::var("PATHEXT") else {
             // PATHEXT variable is not set.

--- a/tests/execute_external.rs
+++ b/tests/execute_external.rs
@@ -1,0 +1,37 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_cli::commands::External;
+
+mod shared;
+use shared::{Result, TEST_FILES, TEST_PREFIX};
+
+#[test]
+pub fn test_execute_external() -> Result<()> {
+    let _dir = shared::init()?;
+
+    for file in TEST_FILES.iter() {
+        println!("{}: ", file.name);
+
+        let external_cmd = External {
+            is_debug: false,
+            pipe_output: true,
+        };
+
+        let cd_name = file.name.trim_start_matches(TEST_PREFIX);
+        let result = external_cmd.execute(cd_name, &[]);
+        // assert_eq!(result.is_ok(), file.should_be_listed);
+
+        if let Ok(result) = result {
+            assert_eq!(result.code, 0);
+            assert!(result.stdout.is_some());
+            assert!(result.stderr.is_some());
+
+            let stdout = result.stdout.unwrap();
+            let stderr = result.stderr.unwrap();
+            assert_eq!(std::str::from_utf8(&stdout).unwrap().trim(), file.content);
+            assert_eq!(std::str::from_utf8(&stderr).unwrap().trim(), "");
+        }
+    }
+
+    Ok(())
+}

--- a/tests/execute_external.rs
+++ b/tests/execute_external.rs
@@ -1,6 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_cli::commands::External;
+use clientele::SysexitsError::*;
 
 mod shared;
 use shared::{Result, TEST_FILES, TEST_PREFIX};
@@ -22,7 +23,7 @@ pub fn test_execute_external() -> Result<()> {
         // assert_eq!(result.is_ok(), file.should_be_listed);
 
         if let Ok(result) = result {
-            assert_eq!(result.code, 0);
+            assert_eq!(result.code, EX_OK);
             assert!(result.stdout.is_some());
             assert!(result.stderr.is_some());
 

--- a/tests/execute_help_cmd.rs
+++ b/tests/execute_help_cmd.rs
@@ -1,6 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_cli::commands::HelpCmd;
+use clientele::SysexitsError::*;
 
 mod shared;
 use shared::{Result, TEST_FILES, TEST_PREFIX};
@@ -19,7 +20,7 @@ pub fn test_execute_help_cmd() -> Result<()> {
         // assert_eq!(result.is_ok(), file.should_be_listed);
 
         if let Ok(result) = result {
-            assert_eq!(result.code, 0);
+            assert_eq!(result.code, EX_OK);
 
             assert_eq!(
                 std::str::from_utf8(&result.output).unwrap().trim(),

--- a/tests/execute_help_cmd.rs
+++ b/tests/execute_help_cmd.rs
@@ -1,0 +1,32 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_cli::commands::HelpCmd;
+
+mod shared;
+use shared::{Result, TEST_FILES, TEST_PREFIX};
+
+#[test]
+pub fn test_execute_help_cmd() -> Result<()> {
+    let _dir = shared::init()?;
+
+    for file in TEST_FILES.iter() {
+        println!("{}: ", file.name);
+
+        let external_cmd = HelpCmd { is_debug: false };
+
+        let cd_name = file.name.trim_start_matches(TEST_PREFIX);
+        let result = external_cmd.execute(cd_name, &[]);
+        // assert_eq!(result.is_ok(), file.should_be_listed);
+
+        if let Ok(result) = result {
+            assert_eq!(result.code, 0);
+
+            assert_eq!(
+                std::str::from_utf8(&result.output).unwrap().trim(),
+                file.help
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/tests/find.rs
+++ b/tests/find.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use asimov_cli::ExternalCommands;
+use asimov_cli::SubcommandsProvider;
 
 mod shared;
 use shared::{Result, TEST_FILES};
@@ -13,7 +13,7 @@ pub fn test_find() -> Result<()> {
         println!("{}: ", file.name);
 
         let cd_name = file.name.trim_start_matches("asimov-");
-        let cmd = ExternalCommands::find("asimov-", cd_name);
+        let cmd = SubcommandsProvider::find("asimov-", cd_name);
         let path = dir.child(file.full_name());
 
         // assert_eq!(cmd.is_some(), file.should_be_listed);

--- a/tests/find.rs
+++ b/tests/find.rs
@@ -3,7 +3,7 @@
 use asimov_cli::SubcommandsProvider;
 
 mod shared;
-use shared::{Result, TEST_FILES};
+use shared::{Result, TEST_FILES, TEST_PREFIX};
 
 #[test]
 pub fn test_find() -> Result<()> {
@@ -12,8 +12,8 @@ pub fn test_find() -> Result<()> {
     for file in TEST_FILES {
         println!("{}: ", file.name);
 
-        let cd_name = file.name.trim_start_matches("asimov-");
-        let cmd = SubcommandsProvider::find("asimov-", cd_name);
+        let cd_name = file.name.trim_start_matches(TEST_PREFIX);
+        let cmd = SubcommandsProvider::find(TEST_PREFIX, cd_name);
         let path = dir.child(file.full_name());
 
         // assert_eq!(cmd.is_some(), file.should_be_listed);

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -3,17 +3,17 @@
 use asimov_cli::SubcommandsProvider;
 
 mod shared;
-use shared::{Result, TEST_FILES};
+use shared::{Result, TEST_FILES, TEST_PREFIX};
 
 #[test]
 pub fn test_list() -> Result<()> {
     let dir = shared::init()?;
-    let cmds = SubcommandsProvider::collect("asimov-", 1);
+    let cmds = SubcommandsProvider::collect(TEST_PREFIX, 1);
 
     for file in TEST_FILES {
         println!("{}: ", file.name);
 
-        let cd_name = file.name.trim_start_matches("asimov-");
+        let cd_name = file.name.trim_start_matches(TEST_PREFIX);
         let cmd = cmds.iter().find(|cmd| cmd.name == cd_name);
         let path = dir.child(file.full_name());
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use asimov_cli::ExternalCommands;
+use asimov_cli::SubcommandsProvider;
 
 mod shared;
 use shared::{Result, TEST_FILES};
@@ -8,7 +8,7 @@ use shared::{Result, TEST_FILES};
 #[test]
 pub fn test_list() -> Result<()> {
     let dir = shared::init()?;
-    let cmds = ExternalCommands::collect("asimov-", 1);
+    let cmds = SubcommandsProvider::collect("asimov-", 1);
 
     for file in TEST_FILES {
         println!("{}: ", file.name);

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -1,5 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
+use indoc::formatdoc;
 use temp_dir::TempDir;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -7,6 +8,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 pub struct TestFile {
     pub name: &'static str,
     pub content: &'static str,
+    pub help: &'static str,
     #[allow(dead_code)]
     pub should_be_listed: bool,
     #[allow(dead_code)]
@@ -28,18 +30,21 @@ pub static TEST_FILES: &[TestFile] = &[
     TestFile {
         name: "asimov-hello",
         content: "Hello, world!",
+        help: "Prints 'Hello, world!'",
         should_be_listed: true,
         win_ext: "bat",
     },
     TestFile {
         name: "asimov-two-levels",
         content: "Should be filtered out!",
+        help: "This file is not listed",
         should_be_listed: false,
         win_ext: "bat",
     },
     TestFile {
         name: "abcdefg-test",
         content: "Shouldn't appear!",
+        help: "This file is not listed too",
         should_be_listed: false,
         win_ext: "bat",
     },
@@ -47,6 +52,7 @@ pub static TEST_FILES: &[TestFile] = &[
     TestFile {
         name: "asimov-hola",
         content: "Hola mundo!",
+        help: "This is windows-only subcommand",
         should_be_listed: true,
         win_ext: "cmd",
     },
@@ -63,7 +69,18 @@ pub fn init() -> Result<TempDir> {
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
 
-        let content = format!("#!/bin/sh\n{}", file.content);
+        #[rustfmt::skip]
+        let content = formatdoc!(r#"
+            #!/bin/sh
+            if [ "$1" = "--help" ]; then
+                echo "{help}"
+            else
+                echo "{content}"
+            fi"#,
+            help = file.help,
+            content = file.content,
+        );
+
         let path = dir.child(file.name);
         let mut file = OpenOptions::new()
             .write(true)
@@ -77,7 +94,19 @@ pub fn init() -> Result<TempDir> {
     #[cfg(windows)]
     for file in TEST_FILES {
         let name = file.full_name();
-        let content = format!("@echo off\n{}", file.content);
+
+        #[rustfmt::skip]
+        let content = formatdoc!(r#"
+            @echo off
+            if "%~1" == "--help" (
+                echo {help}
+            ) else (
+                echo {content}
+            )"#,
+            help = file.help,
+            content = file.content,
+        );
+
         std::fs::write(dir.child(name), content)?;
     }
 

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -22,6 +22,8 @@ impl TestFile {
     }
 }
 
+pub static TEST_PREFIX: &str = "asimov-";
+
 pub static TEST_FILES: &[TestFile] = &[
     TestFile {
         name: "asimov-hello",


### PR DESCRIPTION
This PR will provide both `help` & `help CMD` subcommands.
Also does a little refactoring of main file, mainly idiomatically returning error codes instead of using `std::process::exit`, but also moving big chunks of codes to their respective methods.

@race-of-sloths include!