### PR TITLE
Enhance `asimov help`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ asimov-proxy = { version = "25.0.0-dev.3", optional = true }
 clap = { version = "4.5", default-features = false }
 clientele = "0.3"
 color-print = "=0.3.7"
-rayon = "1.10.0"
+rayon = "1.10"
 
 [[bin]]
 name = "asimov"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ asimov-proxy = { version = "25.0.0-dev.3", optional = true }
 clap = { version = "4.5", default-features = false }
 clientele = "0.3"
 color-print = "=0.3.7"
+rayon = "1.10.0"
 
 [[bin]]
 name = "asimov"

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -55,13 +55,8 @@ impl Help {
     fn collect_output(&self) -> Vec<(String, String)> {
         const MAX_WAIT_TIME: std::time::Duration = std::time::Duration::from_secs(1);
 
-        let commands = SubcommandsProvider::collect("asimov-", 1);
-
-        // FIXME: DIRTY DIRTY HACK!
-        // We need to clone the subcommands to obtain Vec<_> from SubcommandsProvider,
-        // since it doesn't implement into_iter() or into_vec().
-        // Fix it with a new release of `clientele`.
-        let commands = commands.iter().cloned().collect::<Vec<_>>();
+        let provider = SubcommandsProvider::collect("asimov-", 1);
+        let commands = provider.get_commands();
 
         let start_time = std::time::Instant::now();
 

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,12 +1,100 @@
 // This is free and unencumbered software released into the public domain.
 
+use clientele::SubcommandsProvider;
+use clientele::SysexitsError::{self, *};
+use rayon::prelude::*;
+use std::process::Stdio;
+
 use crate::Result;
 
+pub struct CommandDescription {
+    pub name: String,
+    pub description: String,
+    pub usage: Option<String>,
+}
+
 /// Prints extensive help message, executing `help` command for each subcommand.
-pub struct Help;
+pub struct Help {
+    pub is_debug: bool,
+}
 
 impl Help {
-    pub fn execute(&self) -> Result {
-        unimplemented!()
+    pub fn execute(&self) -> Vec<CommandDescription> {
+        let output = self.collect_output();
+
+        let mut result = vec![];
+        for (name, description) in output {
+            let lines = description.lines().collect::<Vec<_>>();
+            let description = lines[0];
+            let usage = lines.iter().find(|line| line.starts_with("Usage:"));
+
+            result.push(CommandDescription {
+                name,
+                description: description.to_string(),
+                usage: usage.map(|usage| usage.to_string()),
+            });
+        }
+
+        result
+    }
+
+    fn is_child_running(&self, child: &mut std::process::Child) -> Result<bool, std::io::Error> {
+        Ok(child.try_wait()?.is_none())
+    }
+
+    fn collect_output(&self) -> Vec<(String, String)> {
+        const MAX_WAIT_TIME: std::time::Duration = std::time::Duration::from_secs(1);
+
+        let commands = SubcommandsProvider::collect("asimov-", 1);
+
+        // FIXME: DIRTY DIRTY HACK!
+        // We need to clone the subcommands to obtain Vec<_> from SubcommandsProvider,
+        // since it doesn't implement into_iter() or into_vec().
+        // Fix it with a new release of `clientele`.
+        let commands = commands.iter().cloned().collect::<Vec<_>>();
+
+        let start_time = std::time::Instant::now();
+
+        commands
+            .par_iter()
+            .filter_map(|cmd| {
+                let Ok(mut child) = std::process::Command::new(&cmd.path)
+                    .args(["--help"])
+                    .stdin(Stdio::inherit())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .spawn()
+                else {
+                    return None;
+                };
+
+                loop {
+                    let Ok(is_running) = self.is_child_running(&mut child) else {
+                        return None;
+                    };
+
+                    if !is_running {
+                        break;
+                    }
+
+                    let now = std::time::Instant::now();
+                    if now.duration_since(start_time) > MAX_WAIT_TIME {
+                        child.kill();
+                        drop(child);
+                        return None;
+                    }
+
+                    rayon::yield_local();
+                }
+
+                let output = child.wait_with_output().unwrap();
+                if !output.status.success() {
+                    return None;
+                }
+
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                Some((cmd.name.clone(), stdout.to_string()))
+            })
+            .collect()
     }
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -23,12 +23,24 @@ impl Help {
         let mut result = vec![];
         for (name, description) in output {
             let lines = description.lines().collect::<Vec<_>>();
-            let description = lines[0];
             let usage = lines.iter().find(|line| line.starts_with("Usage:"));
+
+            // Parse description until the end or an empty line.
+            let description = lines
+                .iter()
+                .map_while(|line| {
+                    if !line.trim().is_empty() {
+                        Some(line.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
 
             result.push(CommandDescription {
                 name,
-                description: description.to_string(),
+                description,
                 usage: usage.map(|usage| usage.to_string()),
             });
         }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -14,9 +14,7 @@ pub struct CommandDescription {
 }
 
 /// Prints extensive help message, executing `help` command for each subcommand.
-pub struct Help {
-    pub is_debug: bool,
-}
+pub struct Help;
 
 impl Help {
     pub fn execute(&self) -> Vec<CommandDescription> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,10 @@ pub fn main() -> SysexitsError {
     };
 
     // Parse command-line options:
-    let options = Options::parse_from(&args);
+    let Ok(options) = Options::try_parse_from(&args) else {
+        print_help();
+        return EX_OK;
+    };
 
     // Print the version, if requested:
     if options.flags.version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,8 +114,16 @@ pub fn main() -> SysexitsError {
 
                 result.map(|result| result.code)
             } else {
-                let cmd = Help;
-                cmd.execute()
+                let cmd = Help {
+                    is_debug: options.flags.debug,
+                };
+
+                let result = cmd.execute();
+                for cmd in result {
+                    println!("{}: {}", cmd.name, cmd.description);
+                }
+
+                Ok(EX_OK)
             }
         }
         #[cfg(feature = "fetch")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,10 +147,12 @@ fn print_full_help() {
     let cmds = Help.execute();
     for (i, cmd) in cmds.iter().enumerate() {
         if i > 0 {
-            help.push('\n');
+            help.push_str("\n\n")
         }
 
         let predicted_usage = format!("Usage: asimov-{} ", cmd.name);
+
+        let description = cmd.description.replace('\n', "\n\t");
 
         if let Some(usage) = cmd
             .usage
@@ -160,19 +162,19 @@ fn print_full_help() {
             // Usage string starts just as we expected. Skip it and print the arguments only.
 
             help.push_str(&color_print::cformat!(
-                "\t<dim>$</dim> <s>asimov {}</s> {} - {}",
+                "\t<dim>$</dim> <s>asimov {}</s> {}\n\t{}",
                 cmd.name,
                 usage,
-                cmd.description,
+                description,
             ));
         } else {
             // Either usage unavailable or it doesn't start with the expected string,
             // fallback to the default message.
 
             help.push_str(&color_print::cformat!(
-                "\t<dim>$</dim> <s>asimov {}</s> [OPTIONS] [COMMAND] - {}",
+                "\t<dim>$</dim> <s>asimov {}</s> [OPTIONS] [COMMAND]\n\t{}",
                 cmd.name,
-                cmd.description
+                description
             ));
         }
     }


### PR DESCRIPTION
This PR adds 2 features:
- Prints custom help with all subcommands available (just like if you used `--help`) when no arguments are present.
- Implement `help` command just like discussed in #21 

While the logic for `help` command is done, I am unsure about "design". Should we print regular help? In which format should we print commands and their usage? Etc.

This is how it looks right now:
![image](https://github.com/user-attachments/assets/c0fe3d64-dce4-4795-a4ce-5012b19fea18)

Would love to hear your opinion.

@race-of-sloths include