### PR TITLE
Implement `fetch` and `import` using resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ publish = true
 
 [features]
 default = ["all"]
-all = ["fetch"]
+all = ["fetch", "import"]
 fetch = ["dep:asimov-proxy"]
 import = ["dep:asimov-proxy"]
-unstable = ["import"]
+unstable = []
 
 [build-dependencies]
 cfg_aliases = "0.2"
@@ -36,13 +36,16 @@ temp-dir = "0.1"
 indoc = "2.0"
 
 [dependencies]
+asimov-env = "25.0.0-dev.10"
 asimov-proxy = { version = "25.0.0-dev.5", optional = true }
+asimov-module = "25.0.0-dev.10"
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3.2", features = ["gofer"] }
 color-print = "=0.3.7"
 rayon = "1.10"
 miette = { version = "7.5", features = ["fancy"] }
 thiserror = "2"
+serde_yml = { version = "0.0.12", default-features = false }
 
 [[bin]]
 name = "asimov"

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1,57 +1,51 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{StandardOptions, SysexitsError};
+use crate::{commands::External, shared::build_resolver, StandardOptions, SysexitsError};
 use color_print::ceprintln;
-use miette::{IntoDiagnostic, Result};
-use std::io::stdout;
+use miette::Result;
 
 pub fn fetch(urls: &Vec<String>, flags: &StandardOptions) -> Result<(), SysexitsError> {
-    let mut output = stdout().lock();
+    let resolver = build_resolver("fetcher").map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to build a resolver: {e}");
+        SysexitsError::EX_UNAVAILABLE
+    })?;
 
     for url in urls {
         if flags.verbose > 1 {
-            if url.contains(':') {
-                ceprintln!("<s><c>»</></> Fetching `{}`...", url);
-            } else {
-                ceprintln!("<s><c>»</></> Reading `{}`...", url);
+            ceprintln!("<s><c>»</></> Fetching `{}`...", url);
+        }
+
+        let modules = resolver.resolve(url)?;
+
+        match modules.first() {
+            Some(module) => {
+                let subcommand = format!("{}-fetcher", module.name);
+
+                let cmd = External {
+                    is_debug: flags.debug,
+                    pipe_output: false,
+                };
+
+                let code = cmd
+                    .execute(&subcommand, &[url.to_owned()])
+                    .map(|result| result.code)?;
+                if code.is_failure() {
+                    return Err(code);
+                }
+            }
+            None => {
+                ceprintln!(
+                    "<s,r>error:</> failed to find a module to fetch the URL: `{}`",
+                    url
+                );
+                return Err(SysexitsError::EX_SOFTWARE);
             }
         }
 
-        let mut input = match asimov_proxy::open(url) {
-            Ok(mut input) => input,
-            Err(error) => {
-                let code = SysexitsError::from(&error);
-                let report: miette::Report = FetchError {
-                    url: url.clone(),
-                    cause: error,
-                }
-                .into();
-                eprintln!("{:?}", report);
-                return Err(code);
-            }
-        };
-
-        std::io::copy(&mut input, &mut output)?;
-
         if flags.verbose > 0 {
-            if url.contains(':') {
-                ceprintln!("<s><g>✓</></> Fetched `{}`.", url); // TODO: time duration
-            } else {
-                ceprintln!("<s><g>✓</></> Read `{}`.", url);
-            }
+            ceprintln!("<s><g>✓</></> Fetched `{}`.", url);
         }
     }
 
     Ok(())
-}
-
-#[derive(Debug, thiserror::Error, miette::Diagnostic)]
-#[error("Failed to fetch URL: {url}")]
-#[diagnostic(code("× Error"), url(docsrs))]
-struct FetchError {
-    url: String,
-
-    #[source]
-    #[diagnostic_source]
-    cause: asimov_proxy::Error,
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -1,7 +1,51 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::{StandardOptions, SysexitsError};
+use crate::{commands::External, shared::build_resolver, StandardOptions, SysexitsError};
+use color_print::ceprintln;
+use miette::Result;
 
-pub fn import(_urls: &Vec<String>, _flags: &StandardOptions) -> Result<(), SysexitsError> {
-    Err(SysexitsError::EX_UNAVAILABLE) // TODO
+pub fn import(urls: &Vec<String>, flags: &StandardOptions) -> Result<(), SysexitsError> {
+    let resolver = build_resolver("importer").map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to build a resolver: {e}");
+        SysexitsError::EX_UNAVAILABLE
+    })?;
+
+    for url in urls {
+        if flags.verbose > 1 {
+            ceprintln!("<s,c>»</> Importing `{}`...", url);
+        }
+
+        let modules = resolver.resolve(url)?;
+
+        match modules.first() {
+            Some(module) => {
+                let subcommand = format!("{}-importer", module.name);
+
+                let cmd = External {
+                    is_debug: flags.debug,
+                    pipe_output: false,
+                };
+
+                let code = cmd
+                    .execute(&subcommand, &[url.to_owned()])
+                    .map(|result| result.code)?;
+                if code.is_failure() {
+                    return Err(code);
+                }
+            }
+            None => {
+                ceprintln!(
+                    "<s,r>error:</> failed to find a module to import the URL: `{}`",
+                    url
+                );
+                return Err(SysexitsError::EX_SOFTWARE);
+            }
+        }
+
+        if flags.verbose > 0 {
+            ceprintln!("<s,g>✓</> Imported `{}`.", url);
+        }
+    }
+
+    Ok(())
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,10 +1,74 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::Result;
+use asimov_env::paths::asimov_root;
+use asimov_module::{
+    models::ModuleManifest,
+    resolve::{Resolver, ResolverBuilder},
+};
 use clientele::{Subcommand, SubcommandsProvider, SysexitsError::*};
+use miette::{miette, IntoDiagnostic};
+
+pub(crate) fn build_resolver(pattern: &str) -> miette::Result<Resolver> {
+    let mut builder = ResolverBuilder::new();
+
+    let module_dir_path = asimov_root().join("modules");
+    let module_dir = std::fs::read_dir(&module_dir_path)
+        .map_err(|e| miette!("Failed to read module manifest directory: {e}"))?
+        .filter_map(Result::ok);
+
+    for entry in module_dir {
+        let filename = entry.file_name();
+        let filename = filename.to_string_lossy();
+        if !filename.ends_with(".yml") && !filename.ends_with(".yaml") {
+            continue;
+        }
+        let file = std::fs::File::open(entry.path()).into_diagnostic()?;
+
+        let manifest: ModuleManifest = serde_yml::from_reader(file).map_err(|e| {
+            miette!(
+                "Invalid module manifest at `{}`: {}",
+                entry.path().display(),
+                e
+            )
+        })?;
+
+        if !manifest
+            .provides
+            .programs
+            .iter()
+            .any(|program| program.split('-').next_back().is_some_and(|p| p == pattern))
+        {
+            continue;
+        }
+
+        builder
+            .insert_manifest(&manifest)
+            .map_err(|e| miette!("{e}"))?;
+    }
+
+    builder.build().map_err(|e| miette!("{e}"))
+}
 
 /// Locates the given subcommand or prints an error.
 pub fn locate_subcommand(name: &str) -> Result<Subcommand> {
+    let libexec = asimov_root().join("libexec");
+    if libexec.exists() {
+        let file = std::fs::read_dir(libexec)?
+            .filter_map(Result::ok)
+            .find(|entry| {
+                entry.file_name().to_str().is_some_and(|filename| {
+                    filename.starts_with("asimov-") && filename.ends_with(name)
+                })
+            });
+        if let Some(entry) = file {
+            return Ok(Subcommand {
+                name: format!("asimov-{}", name),
+                path: entry.path(),
+            });
+        }
+    }
+
     match SubcommandsProvider::find("asimov-", name) {
         Some(cmd) => Ok(cmd),
         None => {


### PR DESCRIPTION
Currently these are just using the first one from the list of resolved modules but we definitely want to choose the module in a smarter way, both in here and in the asimov-module resolver lib.