### PR TITLE
Utilise `asimov_installer` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "argfile"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +133,7 @@ name = "asimov-cli"
 version = "25.0.0-dev.9"
 dependencies = [
  "asimov-env",
+ "asimov-installer",
  "asimov-module",
  "asimov-patterns",
  "asimov-proxy",
@@ -153,6 +163,36 @@ dependencies = [
  "cap-std",
  "dogma",
  "getenv",
+]
+
+[[package]]
+name = "asimov-installer"
+version = "25.0.0-dev.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27e28cdc38bf60ed1eb634ab9b5a62400a5f6ff138db23dec3e74f7a51f3c7b"
+dependencies = [
+ "asimov-env",
+ "asimov-module",
+ "bon",
+ "clientele",
+ "dogma",
+ "flate2",
+ "getenv",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yml",
+ "sha2",
+ "slab",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "zip",
 ]
 
 [[package]]
@@ -327,6 +367,15 @@ checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
 dependencies = [
  "bitvec",
  "nom",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -606,6 +655,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +696,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -681,6 +758,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +787,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -830,6 +928,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1066,16 @@ dependencies = [
  "log",
  "rustversion",
  "windows",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1462,6 +1593,7 @@ checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1472,6 +1604,15 @@ checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
 dependencies = [
  "anyhow",
  "version_check",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2399,6 +2540,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shadow-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2585,12 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
@@ -2583,10 +2741,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "temp-dir"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "terminal_size"
@@ -2885,6 +3065,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tz-rs"
@@ -3588,4 +3774,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ miette = { version = "7.5", features = ["fancy"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 url = "2.5"
+asimov-installer = "25.0.0-dev.19"
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ indoc = "2.0"
 
 [dependencies]
 asimov-env = "25.0.0-dev.19"
+asimov-installer = "25.0.0-dev.19"
 asimov-module = "25.0.0-dev.19"
 asimov-patterns = "25.0.0-dev.19"
 asimov-proxy = { version = "25.0.0-dev.19", optional = true }
@@ -52,7 +53,6 @@ miette = { version = "7.5", features = ["fancy"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 url = "2.5"
-asimov-installer = "25.0.0-dev.19"
 
 [profile.release]
 opt-level = "z"

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -92,9 +92,9 @@ pub async fn fetch(
                     let module_count = modules.len();
                     if module_count > 0 {
                         if modules.len() == 1 {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed module that could handle this URL but is disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed modules that could handle this URL but are disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");
                         }
                         ceprintln!("<s,dim>hint:</> A module can be enabled with: `asimov module enable <<module>>`");
                         ceprintln!("<s,dim>hint:</> Available modules:");

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -64,7 +64,7 @@ pub async fn fetch(
                 .await
                 .map_err(|e| {
                     ceprintln!(
-                        "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                        "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                         module.name
                     );
                     EX_IOERR
@@ -110,7 +110,7 @@ pub async fn fetch(
                     .await
                     .map_err(|e| {
                         ceprintln!(
-                            "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                            "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                             module.name
                         );
                         EX_IOERR

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -121,11 +121,8 @@ pub async fn fetch(
             }
         };
 
-        // Locate the correct subcommand:
-        let subcommand = locate_subcommand(&format!("{}-fetcher", module.name))?;
-
         let mut fetcher = asimov_runner::Fetcher::new(
-            &subcommand.path,
+            format!("asimov-{}-fetcher", module.name),
             &input_url,
             GraphOutput::Inherited,
             FetcherOptions::builder()

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -91,7 +91,7 @@ pub async fn fetch(
                     );
                     let module_count = modules.len();
                     if module_count > 0 {
-                        if modules.len() == 1 {
+                        if module_count == 1 {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -4,8 +4,9 @@ use crate::{
     StandardOptions,
     SysexitsError::{self, *},
     commands::External,
-    shared::{build_resolver, locate_subcommand, normalize_url},
+    shared::{locate_subcommand, normalize_url},
 };
+use asimov_module::{ModuleManifest, resolve::Resolver};
 use asimov_runner::{FetcherOptions, GraphOutput};
 use color_print::ceprintln;
 use miette::Result;
@@ -16,8 +17,27 @@ pub async fn fetch(
     output: Option<&str>,
     flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
-    let resolver = build_resolver("fetcher").map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to build a resolver: {e}");
+    let installer = asimov_installer::Installer::default();
+    let installed_modules: Vec<ModuleManifest> = installer
+        .installed_modules()
+        .await
+        .map_err(|e| {
+            ceprintln!("<s,r>error:</> unable to access installed modules: {e}");
+            EX_UNAVAILABLE
+        })?
+        .into_iter()
+        .map(|manifest| manifest.manifest)
+        .filter(|manifest| {
+            manifest
+                .provides
+                .programs
+                .iter()
+                .any(|program| program.ends_with("-fetcher"))
+        })
+        .collect();
+
+    let resolver = Resolver::try_from_iter(installed_modules.iter()).map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to build resolver: {e}");
         EX_UNAVAILABLE
     })?;
 
@@ -28,20 +48,77 @@ pub async fn fetch(
 
         let input_url = normalize_url(input_url);
 
-        let modules = resolver.resolve(&input_url).unwrap(); // FIXME
+        let modules = resolver.resolve(&input_url).map_err(|e| {
+            ceprintln!("<s,r>error:</> unable to handle URL `{input_url}`: {e}");
+            EX_USAGE
+        })?;
 
         let module = if let Some(want) = module {
-            modules.iter().find(|m| m.name == want).ok_or_else(|| {
+            let module = modules.iter().find(|m| m.name == want).ok_or_else(|| {
                 ceprintln!("<s,r>error:</> failed to find a module named `{want}` that supports fetching the URL: `{input_url}`");
                 EX_SOFTWARE
-            })?
-        } else {
-            modules.first().ok_or_else(|| {
+            })?;
+
+            if installer
+                .is_module_enabled(&module.name)
+                .await
+                .map_err(|e| {
+                    ceprintln!(
+                        "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                        module.name
+                    );
+                    EX_IOERR
+                })?
+            {
+                module
+            } else {
                 ceprintln!(
-                    "<s,r>error:</> failed to find a module to fetch the URL: `{input_url}`"
+                    "<s,r>error:</> module <s>{}</> is not enabled.",
+                    module.name
                 );
-                EX_SOFTWARE
-            })?
+                ceprintln!(
+                    "<s,dim>hint:</> It can be enabled with: `asimov module enable {}`",
+                    module.name
+                );
+                return Err(EX_UNAVAILABLE);
+            }
+        } else {
+            let mut iter = modules.iter();
+            loop {
+                let module = iter.next().ok_or_else(|| {
+                    ceprintln!(
+                        "<s,r>error:</> failed to find a module to fetch the URL: `{input_url}`"
+                    );
+                    let module_count = modules.len();
+                    if module_count > 0 {
+                        if modules.len() == 1 {
+                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed module that could handle this URL but is disabled.");
+                        } else {
+                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed modules that could handle this URL but are disabled.");
+                        }
+                        ceprintln!("<s,dim>hint:</> A module can be enabled with: `asimov module enable <<module>>`");
+                        ceprintln!("<s,dim>hint:</> Available modules:");
+                        for module in &modules {
+                            ceprintln!("<s,dim>hint:</>\t<s>{}</>", module.name);
+                        }
+                    }
+                    EX_UNAVAILABLE
+                })?;
+
+                if installer
+                    .is_module_enabled(&module.name)
+                    .await
+                    .map_err(|e| {
+                        ceprintln!(
+                            "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                            module.name
+                        );
+                        EX_IOERR
+                    })?
+                {
+                    break module;
+                }
+            }
         };
 
         // Locate the correct subcommand:

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -65,7 +65,7 @@ pub async fn list(
                 .await
                 .map_err(|e| {
                     ceprintln!(
-                        "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                        "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                         module.name
                     );
                     EX_IOERR
@@ -111,7 +111,7 @@ pub async fn list(
                     .await
                     .map_err(|e| {
                         ceprintln!(
-                            "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                            "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                             module.name
                         );
                         EX_IOERR

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -88,7 +88,7 @@ pub async fn list(
             loop {
                 let module = iter.next().ok_or_else(|| {
                     ceprintln!(
-                        "<s,r>error:</> failed to find a module to catalogue the URL: `{input_url}`"
+                        "<s,r>error:</> failed to find a module to catalog the URL: `{input_url}`"
                     );
                     let module_count = modules.len();
                     if module_count > 0 {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -92,7 +92,7 @@ pub async fn list(
                     );
                     let module_count = modules.len();
                     if module_count > 0 {
-                        if modules.len() == 1 {
+                        if module_count == 1 {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -122,11 +122,8 @@ pub async fn list(
             }
         };
 
-        // Locate the correct subcommand:
-        let subcommand = locate_subcommand(&format!("{}-cataloger", module.name))?;
-
         let mut cataloger = asimov_runner::Cataloger::new(
-            &subcommand.path,
+            format!("asimov-{}-cataloger", module.name),
             &input_url,
             GraphOutput::Inherited,
             CatalogerOptions::builder()

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -6,6 +6,7 @@ use crate::{
     commands::External,
     shared::{build_resolver, locate_subcommand, normalize_url},
 };
+use asimov_module::{ModuleManifest, resolve::Resolver};
 use asimov_runner::{CatalogerOptions, GraphOutput};
 use color_print::ceprintln;
 use miette::Result;
@@ -17,8 +18,27 @@ pub async fn list(
     output: Option<&str>,
     flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
-    let resolver = build_resolver("cataloger").map_err(|e| {
-        ceprintln!("<s,r>error:</> failed to build a resolver: {e}");
+    let installer = asimov_installer::Installer::default();
+    let installed_modules: Vec<ModuleManifest> = installer
+        .installed_modules()
+        .await
+        .map_err(|e| {
+            ceprintln!("<s,r>error:</> unable to access installed modules: {e}");
+            EX_UNAVAILABLE
+        })?
+        .into_iter()
+        .map(|manifest| manifest.manifest)
+        .filter(|manifest| {
+            manifest
+                .provides
+                .programs
+                .iter()
+                .any(|program| program.ends_with("-cataloger"))
+        })
+        .collect();
+
+    let resolver = Resolver::try_from_iter(installed_modules.iter()).map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to build resolver: {e}");
         EX_UNAVAILABLE
     })?;
 
@@ -29,20 +49,77 @@ pub async fn list(
 
         let input_url = normalize_url(input_url);
 
-        let modules = resolver.resolve(&input_url).unwrap(); // FIXME
+        let modules = resolver.resolve(&input_url).map_err(|e| {
+            ceprintln!("<s,r>error:</> unable to handle URL `{input_url}`: {e}");
+            EX_USAGE
+        })?;
 
         let module = if let Some(want) = module {
-            modules.iter().find(|m| m.name == want).ok_or_else(|| {
+            let module = modules.iter().find(|m| m.name == want).ok_or_else(|| {
                 ceprintln!("<s,r>error:</> failed to find a module named `{want}` that supports cataloging the URL: `{input_url}`");
                 EX_SOFTWARE
-            })?
-        } else {
-            modules.first().ok_or_else(|| {
+            })?;
+
+            if installer
+                .is_module_enabled(&module.name)
+                .await
+                .map_err(|e| {
+                    ceprintln!(
+                        "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                        module.name
+                    );
+                    EX_IOERR
+                })?
+            {
+                module
+            } else {
                 ceprintln!(
-                    "<s,r>error:</> failed to find a module to catalog the URL: `{input_url}`"
+                    "<s,r>error:</> module <s>{}</> is not enabled.",
+                    module.name
                 );
-                EX_SOFTWARE
-            })?
+                ceprintln!(
+                    "<s,dim>hint:</> It can be enabled with: `asimov module enable {}`",
+                    module.name
+                );
+                return Err(EX_UNAVAILABLE);
+            }
+        } else {
+            let mut iter = modules.iter();
+            loop {
+                let module = iter.next().ok_or_else(|| {
+                    ceprintln!(
+                        "<s,r>error:</> failed to find a module to catalogue the URL: `{input_url}`"
+                    );
+                    let module_count = modules.len();
+                    if module_count > 0 {
+                        if modules.len() == 1 {
+                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed module that could handle this URL but is disabled.");
+                        } else {
+                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed modules that could handle this URL but are disabled.");
+                        }
+                        ceprintln!("<s,dim>hint:</> A module can be enabled with: `asimov module enable <<module>>`");
+                        ceprintln!("<s,dim>hint:</> Available modules:");
+                        for module in &modules {
+                            ceprintln!("<s,dim>hint:</>\t<s>{}</>", module.name);
+                        }
+                    }
+                    EX_UNAVAILABLE
+                })?;
+
+                if installer
+                    .is_module_enabled(&module.name)
+                    .await
+                    .map_err(|e| {
+                        ceprintln!(
+                            "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                            module.name
+                        );
+                        EX_IOERR
+                    })?
+                {
+                    break module;
+                }
+            }
         };
 
         // Locate the correct subcommand:

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -93,9 +93,9 @@ pub async fn list(
                     let module_count = modules.len();
                     if module_count > 0 {
                         if modules.len() == 1 {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed module that could handle this URL but is disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed modules that could handle this URL but are disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");
                         }
                         ceprintln!("<s,dim>hint:</> A module can be enabled with: `asimov module enable <<module>>`");
                         ceprintln!("<s,dim>hint:</> Available modules:");

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -60,7 +60,7 @@ pub async fn read(
                 .await
                 .map_err(|e| {
                     ceprintln!(
-                        "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                        "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                         module.name
                     );
                     EX_IOERR
@@ -106,7 +106,7 @@ pub async fn read(
                     .await
                     .map_err(|e| {
                         ceprintln!(
-                            "<s,r>error:</> failed to check whether module `{}` is enabled: {e}",
+                            "<s,r>error:</> error while checking whether module `{}` is enabled: {e}",
                             module.name
                         );
                         EX_IOERR

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -117,11 +117,8 @@ pub async fn read(
             }
         };
 
-        // Locate the correct subcommand:
-        let subcommand = locate_subcommand(&format!("{}-reader", module.name))?;
-
         let mut reader = asimov_runner::Reader::new(
-            &subcommand.path,
+            format!("asimov-{}-reader", module.name),
             AnyInput::Ignored, // FIXME: &input_url,
             GraphOutput::Inherited,
             ReaderOptions::builder()

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -87,7 +87,7 @@ pub async fn read(
                     );
                     let module_count = modules.len();
                     if module_count > 0 {
-                        if modules.len() == 1 {
+                        if module_count == 1 {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
                             ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -88,9 +88,9 @@ pub async fn read(
                     let module_count = modules.len();
                     if module_count > 0 {
                         if modules.len() == 1 {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed module that could handle this URL but is disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed module that could handle this URL but is disabled.");
                         } else {
-                            ceprintln!("<s,dim>hint:</> You have <s>{module_count}</> installed modules that could handle this URL but are disabled.");
+                            ceprintln!("<s,dim>hint:</> Found <s>{module_count}</> installed modules that could handle this URL but are disabled.");
                         }
                         ceprintln!("<s,dim>hint:</> A module can be enabled with: `asimov module enable <<module>>`");
                         ceprintln!("<s,dim>hint:</> Available modules:");

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -55,23 +55,6 @@ pub(crate) fn build_resolver(pattern: &str) -> miette::Result<Resolver> {
 
 /// Locates the given subcommand or prints an error.
 pub fn locate_subcommand(name: &str) -> Result<Subcommand> {
-    let libexec = asimov_root().join("libexec");
-    if libexec.exists() {
-        let file = std::fs::read_dir(libexec)?
-            .filter_map(Result::ok)
-            .find(|entry| {
-                entry.file_name().to_str().is_some_and(|filename| {
-                    filename.starts_with("asimov-") && filename.ends_with(name)
-                })
-            });
-        if let Some(entry) = file {
-            return Ok(Subcommand {
-                name: format!("asimov-{}", name),
-                path: entry.path(),
-            });
-        }
-    }
-
     match SubcommandsProvider::find("asimov-", name) {
         Some(cmd) => Ok(cmd),
         None => {


### PR DESCRIPTION
Use `asimov_installer::Installer` to correctly handle reading installed/enabled modules.
`fetch`/`list`/`read` will only use *enabled* modules.

Also adds some usage hints, examples:

<img width="849" height="194" alt="Screenshot 2025-07-31 at 19 06 50" src="https://github.com/user-attachments/assets/90d4be24-4e54-417f-9d06-b4a3cb39f8ad" />
<img width="875" height="75" alt="Screenshot 2025-07-31 at 19 07 30" src="https://github.com/user-attachments/assets/982f3504-f086-4551-8ca8-72007b65f978" />


@race-of-sloths