### PR TITLE
Use `asimov_registry`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,11 @@ temp-dir = "0.1"
 indoc = "2.0"
 
 [dependencies]
-asimov-env = "25.0.0-dev.19"
-asimov-installer = "25.0.0-dev.19"
-asimov-module = "25.0.0-dev.19"
-asimov-patterns = "25.0.0-dev.19"
-asimov-runner = "25.0.0-dev.19"
+asimov-env = "25.0.0-dev.21"
+asimov-module = "25.0.0-dev.21"
+asimov-patterns = "25.0.0-dev.21"
+asimov-registry = "25.0.0-dev.21"
+asimov-runner = "25.0.0-dev.21"
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3.8", features = ["gofer"] }
 color-print = "=0.3.7"

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -17,8 +17,8 @@ pub async fn fetch(
     output: Option<&str>,
     flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
-    let installer = asimov_installer::Installer::default();
-    let installed_modules: Vec<ModuleManifest> = installer
+    let registry = asimov_registry::Registry::default();
+    let installed_modules: Vec<ModuleManifest> = registry
         .installed_modules()
         .await
         .map_err(|e| {
@@ -59,7 +59,7 @@ pub async fn fetch(
                 EX_SOFTWARE
             })?;
 
-            if installer
+            if registry
                 .is_module_enabled(&module.name)
                 .await
                 .map_err(|e| {
@@ -105,7 +105,7 @@ pub async fn fetch(
                     EX_UNAVAILABLE
                 })?;
 
-                if installer
+                if registry
                     .is_module_enabled(&module.name)
                     .await
                     .map_err(|e| {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -18,8 +18,8 @@ pub async fn list(
     output: Option<&str>,
     flags: &StandardOptions,
 ) -> Result<(), SysexitsError> {
-    let installer = asimov_installer::Installer::default();
-    let installed_modules: Vec<ModuleManifest> = installer
+    let registry = asimov_registry::Registry::default();
+    let installed_modules: Vec<ModuleManifest> = registry
         .installed_modules()
         .await
         .map_err(|e| {
@@ -60,7 +60,7 @@ pub async fn list(
                 EX_SOFTWARE
             })?;
 
-            if installer
+            if registry
                 .is_module_enabled(&module.name)
                 .await
                 .map_err(|e| {
@@ -106,7 +106,7 @@ pub async fn list(
                     EX_UNAVAILABLE
                 })?;
 
-                if installer
+                if registry
                     .is_module_enabled(&module.name)
                     .await
                     .map_err(|e| {


### PR DESCRIPTION
Replaces `asimov_installer` with https://github.com/asimov-platform/asimov.rs/pull/29

This PR will fail until that one is merged and asimov.rs crates `v21` are published.

@race-of-sloths