### PR TITLE
Implement a `snap` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "asimov-proxy",
  "asimov-registry",
  "asimov-runner",
+ "asimov-snapshot",
  "cc",
  "cfg_aliases",
  "clap",
@@ -255,6 +256,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "asimov-snapshot"
+version = "25.0.0-dev.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c6f5d06570bf199f60d2462600b30cd6c72aafa148a9f4f2977909443a193d"
+dependencies = [
+ "asimov-env",
+ "asimov-module",
+ "asimov-patterns",
+ "asimov-runner",
+ "async-trait",
+ "bon",
+ "cap-std",
+ "dogma",
+ "hex",
+ "jiff",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +374,15 @@ checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
 dependencies = [
  "bitvec",
  "nom",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -632,6 +662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +694,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -725,6 +774,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -986,6 +1045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getenv"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1149,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1411,6 +1486,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1828,6 +1927,21 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2426,6 +2540,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shadow-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2897,7 +3022,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2944,6 +3081,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tz-rs"
@@ -3068,6 +3211,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ publish = true
 
 [features]
 default = ["all"]
-all = ["fetch", "list"]
+all = ["fetch", "list", "snap"]
 unstable = ["describe", "index", "read", "search"]
 
 # Optional features:
@@ -28,6 +28,7 @@ index = []
 list = []
 read = []
 search = []
+snap = ["dep:asimov-snapshot"]
 
 [build-dependencies]
 cfg_aliases = "0.2"
@@ -47,6 +48,7 @@ asimov-module = "25.0.0-dev.21"
 asimov-patterns = "25.0.0-dev.21"
 asimov-registry = "25.0.0-dev.21"
 asimov-runner = "25.0.0-dev.21"
+asimov-snapshot = { version = "25.0.0-dev.21", optional = true }
 clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3.8", features = ["gofer"] }
 color-print = "=0.3.7"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,3 +26,6 @@ pub mod read;
 
 #[cfg(feature = "search")]
 pub mod search;
+
+#[cfg(feature = "snap")]
+pub mod snap;

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -1,0 +1,50 @@
+// This is free and unencumbered software released into the public domain.
+
+use crate::{
+    StandardOptions,
+    SysexitsError::{self, *},
+    commands::External,
+    shared::{build_resolver, locate_subcommand, normalize_url},
+};
+use asimov_env::paths::asimov_root;
+use asimov_module::{ModuleManifest, resolve::Resolver};
+use color_print::ceprintln;
+use miette::Result;
+
+pub async fn snap(input_urls: &Vec<String>, flags: &StandardOptions) -> Result<(), SysexitsError> {
+    let registry = asimov_registry::Registry::default();
+
+    let enabled_modules = registry
+        .enabled_modules()
+        .await
+        .map_err(|e| {
+            ceprintln!("<s,r>error:</> unable to access enabled modules: {e}");
+            EX_UNAVAILABLE
+        })?
+        .into_iter()
+        .map(|manifest| manifest.manifest);
+
+    let resolver = Resolver::try_from_iter(enabled_modules).map_err(|e| {
+        ceprintln!("<s,r>error:</> failed to build resolver: {e}");
+        EX_UNAVAILABLE
+    })?;
+
+    let storage =
+        asimov_snapshot::storage::Fs::for_dir(asimov_root().join("snapshots")).map_err(|e| {
+            ceprintln!("<s,r>error:</> failed to create snapshot storage: {e}");
+            EX_UNAVAILABLE
+        })?;
+
+    let mut snapshotter =
+        asimov_snapshot::Snapshotter::new(resolver, storage, asimov_snapshot::Options::default());
+
+    for input_url in input_urls {
+        let input_url = normalize_url(input_url);
+        snapshotter.snapshot(&input_url).await.map_err(|e| {
+            ceprintln!("<s,r>error:</> failed to create snapshot URL `{input_url}`: {e}");
+            EX_UNAVAILABLE
+        })?;
+    }
+
+    Ok(())
+}

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -4,7 +4,7 @@ use crate::{
     StandardOptions,
     SysexitsError::{self, *},
     commands::External,
-    shared::{build_resolver, locate_subcommand, normalize_url},
+    shared::{normalize_url},
 };
 use asimov_env::paths::asimov_root;
 use asimov_module::{ModuleManifest, resolve::Resolver};

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -10,7 +10,7 @@ use asimov_module::{ModuleManifest, resolve::Resolver};
 use color_print::ceprintln;
 use miette::Result;
 
-pub async fn snap(input_urls: &Vec<String>, flags: &StandardOptions) -> Result<(), SysexitsError> {
+pub async fn snap(input_urls: &[String], flags: &StandardOptions) -> Result<(), SysexitsError> {
     let registry = asimov_registry::Registry::default();
 
     let enabled_modules = registry

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -3,14 +3,14 @@
 use crate::{
     StandardOptions,
     SysexitsError::{self, *},
-    shared::{normalize_url},
+    shared::normalize_url,
 };
 use asimov_env::paths::asimov_root;
 use asimov_module::{ModuleManifest, resolve::Resolver};
 use color_print::ceprintln;
 use miette::Result;
 
-pub async fn snap(input_urls: &[String], flags: &StandardOptions) -> Result<(), SysexitsError> {
+pub async fn snap(input_urls: &[String], _flags: &StandardOptions) -> Result<(), SysexitsError> {
     let registry = asimov_registry::Registry::default();
 
     let enabled_modules = registry

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -3,7 +3,6 @@
 use crate::{
     StandardOptions,
     SysexitsError::{self, *},
-    commands::External,
     shared::{normalize_url},
 };
 use asimov_env::paths::asimov_root;

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ enum Command {
         prompt: String,
     },
 
+    /// Save a snapshot for a URL, utilizing enabled modules
+    #[cfg(feature = "snap")]
+    Snap { urls: Vec<String> },
+
     #[clap(external_subcommand)]
     External(Vec<String>),
 }
@@ -246,6 +250,11 @@ pub async fn main() -> SysexitsError {
                 .await
                 .map(|_| EX_OK)
         },
+
+        #[cfg(feature = "snap")]
+        Command::Snap { urls } => commands::snap::snap(urls, &options.flags)
+            .await
+            .map(|_| EX_OK),
 
         Command::External(args) => {
             let cmd = External {


### PR DESCRIPTION
Use:
```console
$ cargo run -q -- snap https://asimov.sh
```

This only captures and saves a snapshot, the content is not displayed. Let me know if that was desired behavior.

Also we/I should upgrade the snapshot implementation to support not only `fetcher` but at least `reader` pattern too.

@race-of-sloths