### PR TITLE
Add a hint when no modules are installed

### DIFF
--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -23,6 +23,16 @@ pub async fn fetch(
         .await
         .map_err(|e| {
             ceprintln!("<s,r>error:</> unable to access installed modules: {e}");
+            match e {
+                asimov_registry::error::InstalledModulesError::DirIo(_, err)
+                    if err.kind() == std::io::ErrorKind::NotFound => {
+                        ceprintln!("<s,dim>hint:</> There appears to be no installed modules.");
+                        ceprintln!("<s,dim>hint:</> Modules may be discovered either on the site <u>https://asimov.directory/modules</>");
+                        ceprintln!("<s,dim>hint:</> or on the GitHub organization <u>https://github.com/asimov-modules</>");
+                        ceprintln!("<s,dim>hint:</> and installed with `asimov module install <<module>>`");
+                    },
+                _ => (),
+            };
             EX_UNAVAILABLE
         })?
         .into_iter()

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -24,6 +24,16 @@ pub async fn list(
         .await
         .map_err(|e| {
             ceprintln!("<s,r>error:</> unable to access installed modules: {e}");
+            match e {
+                asimov_registry::error::InstalledModulesError::DirIo(_, err)
+                    if err.kind() == std::io::ErrorKind::NotFound => {
+                        ceprintln!("<s,dim>hint:</> There appears to be no installed modules.");
+                        ceprintln!("<s,dim>hint:</> Modules may be discovered either on the site <u>https://asimov.directory/modules</>");
+                        ceprintln!("<s,dim>hint:</> or on the GitHub organization <u>https://github.com/asimov-modules</>");
+                        ceprintln!("<s,dim>hint:</> and installed with `asimov module install <<module>>`");
+                    },
+                _ => (),
+            };
             EX_UNAVAILABLE
         })?
         .into_iter()

--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -22,6 +22,16 @@ pub async fn read(
         .await
         .map_err(|e| {
             ceprintln!("<s,r>error:</> unable to access installed modules: {e}");
+            match e {
+                asimov_registry::error::InstalledModulesError::DirIo(_, err)
+                    if err.kind() == std::io::ErrorKind::NotFound => {
+                        ceprintln!("<s,dim>hint:</> There appears to be no installed modules.");
+                        ceprintln!("<s,dim>hint:</> Modules may be discovered either on the site <u>https://asimov.directory/modules</>");
+                        ceprintln!("<s,dim>hint:</> or on the GitHub organization <u>https://github.com/asimov-modules</>");
+                        ceprintln!("<s,dim>hint:</> and installed with `asimov module install <<module>>`");
+                    },
+                _ => (),
+            };
             EX_UNAVAILABLE
         })?
         .into_iter()

--- a/src/commands/snap.rs
+++ b/src/commands/snap.rs
@@ -18,6 +18,16 @@ pub async fn snap(input_urls: &[String], _flags: &StandardOptions) -> Result<(),
         .await
         .map_err(|e| {
             ceprintln!("<s,r>error:</> unable to access enabled modules: {e}");
+            match e {
+                asimov_registry::error::EnabledModulesError::DirIo(_, err)
+                    if err.kind() == std::io::ErrorKind::NotFound => {
+                        ceprintln!("<s,dim>hint:</> There appears to be no installed modules.");
+                        ceprintln!("<s,dim>hint:</> Modules may be discovered either on the site <u>https://asimov.directory/modules</>");
+                        ceprintln!("<s,dim>hint:</> or on the GitHub organization <u>https://github.com/asimov-modules</>");
+                        ceprintln!("<s,dim>hint:</> and installed with `asimov module install <<module>>`");
+                    },
+                _ => (),
+            };
             EX_UNAVAILABLE
         })?
         .into_iter()


### PR DESCRIPTION
Adds a hint message when `fetch`, `list`, `snap` fails to read modules due to an `std::io::ErrorKind::NotFound` error.

Example:
<img width="1638" height="149" alt="Screenshot 2025-08-13 at 15 27 27" src="https://github.com/user-attachments/assets/e8d183f5-2995-41d5-b973-3cfc3170f641" />

@race-of-sloths