### PR TITLE
Pass input as URL in `read`

### DIFF
--- a/src/commands/read.rs
+++ b/src/commands/read.rs
@@ -69,16 +69,12 @@ pub async fn read(
 
         let module = shared::pick_module(&registry, &input_url, &modules, module).await?;
 
-        let input = tokio::fs::File::open(&input_url)
-            .await
-            .map(Box::new)
-            .map(|i| Input::AsyncRead(i))?;
-
         let mut reader = asimov_runner::Reader::new(
             format!("asimov-{}-reader", module.name),
-            input,
+            Input::Ignored,
             GraphOutput::Inherited,
             ReaderOptions::builder()
+                .other(input_url)
                 .maybe_other(flags.debug.then_some("--debug"))
                 .build(),
         );


### PR DESCRIPTION
Instead of `cat $input_url | asimov-xyz-reader` do `asimov-xyz-reader $input_url`.

@race-of-sloths