### PR TITLE
Implement a `module search` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,15 @@ publish = true
 [features]
 default = ["all"]
 all = ["ask", "fetch", "handle", "list", "module", "read", "snap", "snapshot"]
-unstable = ["describe", "index", "message", "module-new", "package", "protocol", "search"]
+unstable = [
+  "describe",
+  "index",
+  "message",
+  "module-new",
+  "package",
+  "protocol",
+  "search",
+]
 
 # Optional features:
 ask = []
@@ -96,10 +104,16 @@ jiff = { version = "0.2", default-features = false, features = [
 ], optional = true }
 mime = { version = "0.3", optional = true }
 sha2 = { version = "0.11", optional = true }
-treelog = { version = "0.0.6", default-features = false, features = ["transform", "walkdir"], optional = true }
+treelog = { version = "0.0.6", default-features = false, features = [
+  "transform",
+  "walkdir",
+], optional = true }
 
 futures-lite = "2.6.1"
-distrib = { version = "0.0.2", default-features = false, features = ["rust", "std"], optional = true }
+distrib = { version = "0.0.2", default-features = false, features = [
+  "rust",
+  "std",
+], optional = true }
 
 [profile.release]
 opt-level = "z"

--- a/src/commands/module.rs
+++ b/src/commands/module.rs
@@ -118,6 +118,17 @@ pub enum ModuleCommand {
         url: String,
     },
 
+    /// Search the index of available modules
+    Search {
+        /// The terms to search for, all of which must match
+        #[clap(required = true)]
+        query: Vec<String>,
+
+        /// Set the output format [default: cli] [possible values: cli, jsonl]
+        #[arg(value_name = "FORMAT", short = 'o', long)]
+        output: Option<String>,
+    },
+
     /// Uninstall a currently installed module
     Uninstall {
         /// The names of the modules to uninstall
@@ -171,6 +182,9 @@ impl ModuleCommand {
                 summary,
             } => new(name, dir.as_deref(), program, summary.as_deref(), flags).await,
             Resolve { url } => resolve(url, flags).await,
+            Search { query, output } => {
+                search(query, output.as_deref().unwrap_or(&"cli"), flags).await
+            },
             Uninstall { names } => uninstall(names, flags).await,
             Upgrade {
                 names,
@@ -222,6 +236,9 @@ pub use new::*;
 
 mod resolve;
 pub use resolve::*;
+
+mod search;
+pub use search::*;
 
 mod uninstall;
 pub use uninstall::*;

--- a/src/commands/module/search.rs
+++ b/src/commands/module/search.rs
@@ -1,0 +1,51 @@
+// This is free and unencumbered software released into the public domain.
+
+use crate::{StandardOptions, SysexitsError::*};
+use color_print::{ceprintln, cprintln};
+use core::error::Error;
+
+pub async fn search(
+    query: &[String],
+    output: &str,
+    _flags: &StandardOptions,
+) -> Result<(), Box<dyn Error>> {
+    let index = asimov_module::Index::fetch().await.map_err(|e| {
+        tracing::error!("failed to fetch the module index: {e}");
+        EX_UNAVAILABLE
+    })?;
+
+    let query = query.join(" ");
+    let modules: Vec<_> = index.search(&query).collect();
+
+    if modules.is_empty() {
+        if output != "jsonl" {
+            ceprintln!("<s,y>!</> No modules matched <s>{query}</>.");
+        }
+        return Ok(());
+    }
+
+    let width = modules
+        .iter()
+        .map(|module| module.name.len())
+        .max()
+        .unwrap_or_default();
+
+    for module in modules {
+        match output {
+            "jsonl" => {
+                let json = serde_json::to_string(module).map_err(|e| {
+                    tracing::error!("failed to serialize module manifest: {e}");
+                    EX_SOFTWARE
+                })?;
+                println!("{json}");
+            },
+            "cli" | _ => {
+                let name = format!("{:width$}", module.name);
+                let summary = module.summary.as_deref().unwrap_or_default();
+                cprintln!("<s,c>{name}</>  {summary}");
+            },
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
DEPENDS ON https://github.com/asimov-platform/asimov-sdk/pull/71

Adds a `module search` command that accepts one or more terms:
<img width="986" height="928" alt="Screenshot 2026-08-04 at 11 14 36" src="https://github.com/user-attachments/assets/cea93a9e-e8a8-4a96-8d72-71338bf6652b" />

- empty terms returns all modules
- multiple terms requires all of them to match

Also searches the programs, protocols, URL patterns, content types, file extensions:
<img width="1075" height="494" alt="Screenshot 2026-08-04 at 11 16 14" src="https://github.com/user-attachments/assets/3d1f1d6c-c6ac-4570-beaa-4ba26fe56cbf" />
<img width="904" height="496" alt="Screenshot 2026-08-04 at 11 39 44" src="https://github.com/user-attachments/assets/7f8a5eb4-2144-4561-8b1a-a7a9036bdc5d" />
<img width="695" height="534" alt="Screenshot 2026-08-04 at 11 38 17" src="https://github.com/user-attachments/assets/324bb175-d4a8-4191-906b-15599d5bee77" />


<!-- Thank you for your valuable contribution to ASIMOV -->
