### PR TITLE
Implement source caching options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "futures-lite",
  "hex",
  "http-body-util",
+ "humantime",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -3333,6 +3334,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ graph = []
 handle = ["asimov-id/encodings"]
 message = []
 package = ["package-scaffold", "dep:distrib", "dep:treelog"]
-package-scaffold = ["dep:asimov-module-kit"] # fka module-new
+package-scaffold = ["dep:asimov-module-kit"]                 # fka module-new
 protocol = ["dep:asimov-protocol"]
 vault = []
 
@@ -94,6 +94,7 @@ clap = { version = "4.5", default-features = false }
 clientele = { version = "0.3.14", features = ["gofer", "serde-json", "tokio"] }
 color-print = "=0.3.7"
 derive_more = { version = "2", features = ["display"] }
+humantime = "2"
 jq = "0.1"
 known-types-pypi = { version = "0.0.1", features = ["serde"] }
 known-types-rubygems = { version = "0.0.1", features = ["serde"] }
@@ -109,7 +110,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yml = { version = "0.0.13", default-features = false }
 thiserror = "2"
-humantime = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
@@ -166,7 +166,9 @@ hyper-util = { version = "0.1", default-features = false, features = [
   "tokio",
 ], optional = true }
 iroh-base = { version = "1.1", default-features = false, features = ["key"] }
-jsonc-parser = { version = "0.33", default-features = false, features = ["cst"], optional = true }
+jsonc-parser = { version = "0.33", default-features = false, features = [
+  "cst",
+], optional = true }
 keyring-core = "1.0"
 rustls = { version = "0.23", default-features = false, features = [
   "logging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yml = { version = "0.0.13", default-features = false }
 thiserror = "2"
+humantime = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/src/commands/source.rs
+++ b/src/commands/source.rs
@@ -19,6 +19,9 @@ pub enum SourceCommand {
         /// The collection URL(s) to examine.
         urls: Vec<String>,
 
+        #[clap(flatten)]
+        cache: cache::CacheArgs,
+
         /// The specific module to use.
         #[clap(long, short = 'M')]
         module: Option<ModuleName>,
@@ -85,7 +88,8 @@ impl SourceCommand {
                 limit,
                 output,
                 jq,
-            } => list(urls, module, sort, offset, limit, output, jq, flags).await,
+                cache,
+            } => list(urls, module, sort, offset, limit, output, jq, cache, flags).await,
 
             Read { module, urls } => read(urls, module, flags).await,
 
@@ -102,6 +106,8 @@ impl SourceCommand {
 
 #[cfg(false)]
 pub mod describe;
+
+mod cache;
 
 mod fetch;
 pub use fetch::*;

--- a/src/commands/source/cache.rs
+++ b/src/commands/source/cache.rs
@@ -1,0 +1,67 @@
+// This is free and unencumbered software released into the public domain.
+
+use clientele::crates::clap::Args;
+use std::time::Duration;
+
+#[derive(Args, Clone, Debug, Default)]
+pub struct CacheArgs {
+    /// Maximum acceptable cache age (for example, 1h or 7d). Default is module-specific.
+    #[arg(long, value_name = "DURATION", value_parser = parse_max_age)]
+    pub max_age: Option<Duration>,
+
+    /// Wait for fresh data, allowing at most this duration for the command (for example, 30s).
+    #[arg(long, value_name = "DURATION", value_parser = humantime::parse_duration)]
+    pub deadline: Option<Duration>,
+}
+
+impl CacheArgs {
+    pub fn max_age_option(&self) -> Option<String> {
+        self.max_age
+            .map(|value| format!("--max-age={}", humantime::format_duration(value)))
+    }
+
+    pub fn deadline_option(&self) -> Option<String> {
+        self.deadline
+            .map(|value| format!("--deadline={}", humantime::format_duration(value)))
+    }
+}
+
+fn parse_max_age(value: &str) -> Result<Duration, String> {
+    let duration = humantime::parse_duration(value).map_err(|error| error.to_string())?;
+    if duration.is_zero() {
+        return Err("max age must be positive".into());
+    }
+    Ok(duration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clientele::crates::clap::Parser;
+
+    #[derive(Parser)]
+    struct Command {
+        #[command(flatten)]
+        cache: CacheArgs,
+    }
+
+    #[test]
+    fn forwards_only_explicit_options() {
+        let args = Command::try_parse_from(["test"]).unwrap().cache;
+        assert_eq!(args.max_age_option(), None);
+        assert_eq!(args.deadline_option(), None);
+        let args = Command::try_parse_from(["test", "--max-age", "1h", "--deadline", "30s"])
+            .unwrap()
+            .cache;
+        assert_eq!(args.max_age_option().as_deref(), Some("--max-age=1h"));
+        assert_eq!(args.deadline_option().as_deref(), Some("--deadline=30s"));
+    }
+
+    #[test]
+    fn rejects_invalid_options() {
+        for args in [["test", "--max-age", "0s"], ["test", "--deadline", "nope"]] {
+            assert!(Command::try_parse_from(args).is_err());
+        }
+        assert!(Command::try_parse_from(["test", "--wait"]).is_err());
+    }
+}

--- a/src/commands/source/fetch.rs
+++ b/src/commands/source/fetch.rs
@@ -23,6 +23,8 @@ pub struct SourceFetchArgs {
     #[arg(long, value_name = "EXPR")]
     jq: Option<String>,
 
+    #[clap(flatten)]
+    cache: super::cache::CacheArgs,
     urls: Vec<String>,
 }
 
@@ -37,6 +39,7 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
         EX_UNAVAILABLE
     })?;
 
+    let mut fetchers = Vec::with_capacity(args.urls.len());
     for input_url in args.urls {
         if flags.verbose > 1 {
             ceprintln!("<s,c>»</> Fetching <s>{}</>...", input_url);
@@ -64,7 +67,7 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
         )
         .await?;
 
-        let mut fetcher = asimov_runner::Fetcher::new(
+        let fetcher = asimov_runner::Fetcher::new(
             format!("asimov-{}-fetcher", module.name),
             &input_url,
             if jq.is_some() {
@@ -74,16 +77,39 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
             },
             FetcherOptions::builder()
                 .maybe_output(args.output.as_deref())
+                .maybe_other(args.cache.max_age_option())
+                .maybe_other(args.cache.deadline_option())
                 .maybe_other(flags.debug.then_some("--debug"))
                 .build(),
         );
 
-        let output = fetcher.execute().await.map_err(|e| {
-            ceprintln!("<s,r>error:</> fetcher execution failed: {e}");
-            EX_UNAVAILABLE
-        })?;
+        fetchers.push((input_url, fetcher));
+    }
 
-        if let Some(filter) = jq.as_ref() {
+    let verbose = flags.verbose;
+
+    let mut js = tokio::task::JoinSet::new();
+    for (url, mut fetcher) in fetchers {
+        js.spawn(async move {
+            fetcher
+                .execute()
+                .await
+                .inspect(|_| {
+                    if verbose > 0 {
+                        ceprintln!("<s,g>✓</> Fetched <s>{}</>.", url)
+                    }
+                })
+                .inspect_err(|err| {
+                    ceprintln!("<s,r>error:</> fetcher execution failed for <s>{url}</>: {err}")
+                })
+        });
+    }
+
+    let outputs = js.join_all().await;
+    let failed = outputs.iter().any(Result::is_err);
+
+    if let Some(filter) = jq.as_ref() {
+        for output in outputs.into_iter().flatten() {
             for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
                 ceprintln!("<s,r>error:</> jq filtering failed: {e}");
                 EX_DATAERR
@@ -91,11 +117,11 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
                 println!("{value}");
             }
         }
-
-        if flags.verbose > 0 {
-            ceprintln!("<s,g>✓</> Fetched <s>{}</>.", input_url);
-        }
     }
 
-    Ok(())
+    if failed {
+        Err(EX_UNAVAILABLE.into())
+    } else {
+        Ok(())
+    }
 }

--- a/src/commands/source/fetch.rs
+++ b/src/commands/source/fetch.rs
@@ -6,6 +6,7 @@ use asimov_runner::{FetcherOptions, GraphOutput};
 use clientele::crates::clap::Args;
 use color_print::ceprintln;
 use miette::Result;
+use std::io::Write;
 
 #[derive(Args, Clone, Debug, Default)]
 pub struct SourceFetchArgs {
@@ -41,14 +42,10 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
 
     let mut fetchers = Vec::with_capacity(args.urls.len());
     for input_url in args.urls {
-        if flags.verbose > 1 {
-            ceprintln!("<s,c>»</> Fetching <s>{}</>...", input_url);
-        }
-
         let input_url = normalize_url(&input_url).unwrap_or_else(|e| {
             if flags.verbose > 1 {
                 ceprintln!(
-                    "<s,y>warning:</> using given unmodified URL, normalization failed: {e}"
+                    "<s,y>warning:</> using unmodified URL <s>{input_url}</>; normalization failed: {e}"
                 );
             }
             input_url.clone()
@@ -70,11 +67,7 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
         let fetcher = asimov_runner::Fetcher::new(
             format!("asimov-{}-fetcher", module.name),
             &input_url,
-            if jq.is_some() {
-                GraphOutput::Captured
-            } else {
-                GraphOutput::Inherited
-            },
+            GraphOutput::Captured,
             FetcherOptions::builder()
                 .maybe_output(args.output.as_deref())
                 .maybe_other(args.cache.max_age_option())
@@ -88,34 +81,38 @@ pub async fn fetch(args: SourceFetchArgs, flags: &StandardOptions) -> Result<(),
 
     let verbose = flags.verbose;
 
-    let mut js = tokio::task::JoinSet::new();
-    for (url, mut fetcher) in fetchers {
-        js.spawn(async move {
-            fetcher
-                .execute()
-                .await
-                .inspect(|_| {
-                    if verbose > 0 {
-                        ceprintln!("<s,g>✓</> Fetched <s>{}</>.", url)
+    let tasks: Vec<_> = fetchers
+        .into_iter()
+        .map(|(url, mut fetcher)| (url, tokio::spawn(async move { fetcher.execute().await })))
+        .collect();
+
+    let mut failed = false;
+    for (url, task) in tasks {
+        if verbose > 1 {
+            ceprintln!("<s,c>»</> Fetching <s>{}</>...", url);
+        }
+        match task.await? {
+            Ok(output) => {
+                let mut stdout = std::io::stdout().lock();
+                if let Some(filter) = jq.as_ref() {
+                    for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
+                        ceprintln!("<s,r>error:</> jq filtering failed for <s>{url}</>: {e}");
+                        EX_DATAERR
+                    })? {
+                        writeln!(stdout, "{value}")?;
                     }
-                })
-                .inspect_err(|err| {
-                    ceprintln!("<s,r>error:</> fetcher execution failed for <s>{url}</>: {err}")
-                })
-        });
-    }
-
-    let outputs = js.join_all().await;
-    let failed = outputs.iter().any(Result::is_err);
-
-    if let Some(filter) = jq.as_ref() {
-        for output in outputs.into_iter().flatten() {
-            for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
-                ceprintln!("<s,r>error:</> jq filtering failed: {e}");
-                EX_DATAERR
-            })? {
-                println!("{value}");
-            }
+                } else {
+                    stdout.write_all(&output.into_inner())?;
+                }
+                stdout.flush()?;
+                if verbose > 0 {
+                    ceprintln!("<s,g>✓</> Fetched <s>{}</>.", url);
+                }
+            },
+            Err(err) => {
+                failed = true;
+                ceprintln!("<s,r>error:</> fetcher execution failed for <s>{url}</>: {err}");
+            },
         }
     }
 

--- a/src/commands/source/list.rs
+++ b/src/commands/source/list.rs
@@ -15,6 +15,7 @@ pub async fn list(
     limit: Option<usize>,
     output: Option<String>,
     jq: Option<String>,
+    cache: super::cache::CacheArgs,
     flags: &StandardOptions,
 ) -> Result<(), BoxError> {
     let jq = shared::compile_jq(jq.as_deref())?;
@@ -26,6 +27,7 @@ pub async fn list(
         EX_UNAVAILABLE
     })?;
 
+    let mut catalogers = Vec::with_capacity(input_urls.len());
     for input_url in input_urls {
         if flags.verbose > 1 {
             ceprintln!("<s,c>»</> Cataloging <s>{}</>...", input_url);
@@ -49,7 +51,7 @@ pub async fn list(
             shared::pick_module(&registry, &input_url, modules.as_slice(), module.as_deref())
                 .await?;
 
-        let mut cataloger = asimov_runner::Cataloger::new(
+        let cataloger = asimov_runner::Cataloger::new(
             format!("asimov-{}-cataloger", module.name),
             &input_url,
             if jq.is_some() {
@@ -62,16 +64,39 @@ pub async fn list(
                 .maybe_offset(offset)
                 .maybe_limit(limit)
                 .maybe_output(output.as_deref())
+                .maybe_other(cache.max_age_option())
+                .maybe_other(cache.deadline_option())
                 .maybe_other(flags.debug.then_some("--debug"))
                 .build(),
         );
 
-        let output = cataloger.execute().await.map_err(|e| {
-            ceprintln!("<s,r>error:</> cataloger execution failed: {e}");
-            EX_UNAVAILABLE
-        })?;
+        catalogers.push((input_url, cataloger));
+    }
 
-        if let Some(filter) = jq.as_ref() {
+    let verbose = flags.verbose;
+
+    let mut js = tokio::task::JoinSet::new();
+    for (url, mut cataloger) in catalogers {
+        js.spawn(async move {
+            cataloger
+                .execute()
+                .await
+                .inspect(|_| {
+                    if verbose > 0 {
+                        ceprintln!("<s,g>✓</> Cataloged <s>{}</>.", url)
+                    }
+                })
+                .inspect_err(|err| {
+                    ceprintln!("<s,r>error:</> cataloger execution failed for <s>{url}</>: {err}")
+                })
+        });
+    }
+
+    let outputs = js.join_all().await;
+    let failed = outputs.iter().any(Result::is_err);
+
+    if let Some(filter) = jq.as_ref() {
+        for output in outputs.into_iter().flatten() {
             for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
                 ceprintln!("<s,r>error:</> jq filtering failed: {e}");
                 EX_DATAERR
@@ -79,11 +104,11 @@ pub async fn list(
                 println!("{value}");
             }
         }
-
-        if flags.verbose > 0 {
-            ceprintln!("<s,g>✓</> Cataloged <s>{}</>.", input_url);
-        }
     }
 
-    Ok(())
+    if failed {
+        Err(EX_UNAVAILABLE.into())
+    } else {
+        Ok(())
+    }
 }

--- a/src/commands/source/list.rs
+++ b/src/commands/source/list.rs
@@ -6,6 +6,7 @@ use asimov_runner::{CatalogerOptions, GraphOutput};
 use clientele::sort::SortKeys;
 use color_print::ceprintln;
 use miette::Result;
+use std::io::Write;
 
 pub async fn list(
     input_urls: Vec<String>,
@@ -29,14 +30,10 @@ pub async fn list(
 
     let mut catalogers = Vec::with_capacity(input_urls.len());
     for input_url in input_urls {
-        if flags.verbose > 1 {
-            ceprintln!("<s,c>»</> Cataloging <s>{}</>...", input_url);
-        }
-
         let input_url = normalize_url(&input_url).unwrap_or_else(|e| {
             if flags.verbose > 1 {
                 ceprintln!(
-                    "<s,y>warning:</> using given unmodified URL, normalization failed: {e}"
+                    "<s,y>warning:</> using unmodified URL <s>{input_url}</>; normalization failed: {e}"
                 );
             }
             input_url.clone()
@@ -54,11 +51,7 @@ pub async fn list(
         let cataloger = asimov_runner::Cataloger::new(
             format!("asimov-{}-cataloger", module.name),
             &input_url,
-            if jq.is_some() {
-                GraphOutput::Captured
-            } else {
-                GraphOutput::Inherited
-            },
+            GraphOutput::Captured,
             CatalogerOptions::builder()
                 .maybe_sort(sort.clone())
                 .maybe_offset(offset)
@@ -75,34 +68,38 @@ pub async fn list(
 
     let verbose = flags.verbose;
 
-    let mut js = tokio::task::JoinSet::new();
-    for (url, mut cataloger) in catalogers {
-        js.spawn(async move {
-            cataloger
-                .execute()
-                .await
-                .inspect(|_| {
-                    if verbose > 0 {
-                        ceprintln!("<s,g>✓</> Cataloged <s>{}</>.", url)
+    let tasks: Vec<_> = catalogers
+        .into_iter()
+        .map(|(url, mut cataloger)| (url, tokio::spawn(async move { cataloger.execute().await })))
+        .collect();
+
+    let mut failed = false;
+    for (url, task) in tasks {
+        if verbose > 1 {
+            ceprintln!("<s,c>»</> Cataloging <s>{}</>...", url);
+        }
+        match task.await? {
+            Ok(output) => {
+                let mut stdout = std::io::stdout().lock();
+                if let Some(filter) = jq.as_ref() {
+                    for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
+                        ceprintln!("<s,r>error:</> jq filtering failed for <s>{url}</>: {e}");
+                        EX_DATAERR
+                    })? {
+                        writeln!(stdout, "{value}")?;
                     }
-                })
-                .inspect_err(|err| {
-                    ceprintln!("<s,r>error:</> cataloger execution failed for <s>{url}</>: {err}")
-                })
-        });
-    }
-
-    let outputs = js.join_all().await;
-    let failed = outputs.iter().any(Result::is_err);
-
-    if let Some(filter) = jq.as_ref() {
-        for output in outputs.into_iter().flatten() {
-            for value in shared::filter_json(filter, output.into_inner()).map_err(|e| {
-                ceprintln!("<s,r>error:</> jq filtering failed: {e}");
-                EX_DATAERR
-            })? {
-                println!("{value}");
-            }
+                } else {
+                    stdout.write_all(&output.into_inner())?;
+                }
+                stdout.flush()?;
+                if verbose > 0 {
+                    ceprintln!("<s,g>✓</> Cataloged <s>{}</>.", url);
+                }
+            },
+            Err(err) => {
+                failed = true;
+                ceprintln!("<s,r>error:</> cataloger execution failed for <s>{url}</>: {err}");
+            },
         }
     }
 


### PR DESCRIPTION
1. Adds options:
   - `--max-age` that controls how the maximum staleness accepted from a cache
   - `--deadline` that controls how long of a timeout should the fetch/list operation use.

   Both use the [humantime](https://crates.io/crates/humantime) crate and they are passed as-is to the module for the operation. The CLI currently makes no attempt at enforcing either option. I didn't add any default for the `--max-age` here either, I feel like that should be module specific.

2. Makes the fetcher/lister execution happen in parallel. This is to at least somewhat attempt to respect the `--deadline` option, otherwise `--deadline 30s` falls into the `30s... 30s...` pattern.
   The output order is currently the same but I think there may be at least one follow up:
   - Stream subprocess output through CLI. This would mean allowing the outputs to interleave.